### PR TITLE
fix(PR-A): Fundação — ApiService, Models separados, OperationalProvider e UserProvider refatorados

### DIFF
--- a/frontend/lib/core/models/inventory_item.dart
+++ b/frontend/lib/core/models/inventory_item.dart
@@ -1,0 +1,83 @@
+// Model separado — InventoryItem com tipos corretos
+class InventoryItem {
+  final String code;
+  final String category;
+  final String description;
+  final double qty;
+  final String unit;
+  final double cost;
+  final String location;
+  final double minimumStock;
+  final String? supplier;
+  final String? lotNumber;
+
+  const InventoryItem({
+    required this.code,
+    required this.category,
+    required this.description,
+    required this.qty,
+    required this.unit,
+    required this.location,
+    this.cost = 0.0,
+    this.minimumStock = 5.0,
+    this.supplier,
+    this.lotNumber,
+  });
+
+  bool get isLowStock => qty <= minimumStock;
+
+  /// Saldo formatado para exibição
+  String get balanceLabel => '${qty % 1 == 0 ? qty.toInt() : qty} $unit';
+
+  /// Valor total do item em estoque
+  double get totalValue => qty * cost;
+
+  InventoryItem copyWith({
+    double? qty,
+    double? cost,
+    String? location,
+    String? supplier,
+    String? lotNumber,
+    double? minimumStock,
+  }) {
+    return InventoryItem(
+      code: code,
+      category: category,
+      description: description,
+      qty: qty ?? this.qty,
+      unit: unit,
+      cost: cost ?? this.cost,
+      location: location ?? this.location,
+      minimumStock: minimumStock ?? this.minimumStock,
+      supplier: supplier ?? this.supplier,
+      lotNumber: lotNumber ?? this.lotNumber,
+    );
+  }
+
+  /// Serialização para cache offline / API
+  Map<String, dynamic> toJson() => {
+        'code': code,
+        'category': category,
+        'description': description,
+        'qty': qty,
+        'unit': unit,
+        'cost': cost,
+        'location': location,
+        'minimum_stock': minimumStock,
+        'supplier': supplier,
+        'lot_number': lotNumber,
+      };
+
+  factory InventoryItem.fromJson(Map<String, dynamic> json) => InventoryItem(
+        code: json['code'] as String,
+        category: json['category'] as String,
+        description: json['description'] as String,
+        qty: (json['qty'] as num).toDouble(),
+        unit: json['unit'] as String,
+        cost: (json['cost'] as num? ?? 0).toDouble(),
+        location: json['location'] as String,
+        minimumStock: (json['minimum_stock'] as num? ?? 5).toDouble(),
+        supplier: json['supplier'] as String?,
+        lotNumber: json['lot_number'] as String?,
+      );
+}

--- a/frontend/lib/core/models/user_model.dart
+++ b/frontend/lib/core/models/user_model.dart
@@ -1,0 +1,46 @@
+// Model de usuário com suporte a JWT claims
+class UserModel {
+  final String id;
+  final String name;
+  final String company;
+  final String role;
+  final String tenantId;
+  final String? profileImageUrl;
+
+  const UserModel({
+    required this.id,
+    required this.name,
+    required this.company,
+    required this.role,
+    required this.tenantId,
+    this.profileImageUrl,
+  });
+
+  bool get isAdmin => role == 'admin' || role == 'owner';
+
+  factory UserModel.fromJwtClaims(Map<String, dynamic> claims) => UserModel(
+        id: claims['sub'] as String? ?? '',
+        name: claims['name'] as String? ?? 'Usuário',
+        company: claims['company'] as String? ?? 'S.F.C.P.C',
+        role: claims['role'] as String? ?? 'operator',
+        tenantId: claims['tenant_id'] as String? ?? '',
+        profileImageUrl: claims['picture'] as String?,
+      );
+
+  factory UserModel.guest() => const UserModel(
+        id: '',
+        name: 'Convidado',
+        company: 'S.F.C.P.C',
+        role: 'guest',
+        tenantId: '',
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'company': company,
+        'role': role,
+        'tenant_id': tenantId,
+        'profile_image_url': profileImageUrl,
+      };
+}

--- a/frontend/lib/core/providers/operational_provider.dart
+++ b/frontend/lib/core/providers/operational_provider.dart
@@ -1,76 +1,168 @@
+// OperationalProvider refatorado — usa InventoryItem tipado + ApiService
 import 'package:flutter/material.dart';
+import '../models/inventory_item.dart';
+import '../services/api_service.dart';
 
-class InventoryItem {
-  final String code;
-  final String category;
-  final String description;
-  final String balance;
-  final String location;
-  final bool isLowStock;
-
-  InventoryItem({
-    required this.code,
-    required this.category,
-    required this.description,
-    required this.balance,
-    required this.location,
-    this.isLowStock = false,
-  });
-
-  InventoryItem copyWith({
-    String? balance,
-    bool? isLowStock,
-  }) {
-    return InventoryItem(
-      code: code,
-      category: category,
-      description: description,
-      balance: balance ?? this.balance,
-      location: location,
-      isLowStock: isLowStock ?? this.isLowStock,
-    );
-  }
-}
+enum ProviderStatus { idle, loading, error }
 
 class OperationalProvider with ChangeNotifier {
-  final List<InventoryItem> _items = [
-    InventoryItem(
-      code: "LINHO-BEGE",
-      category: "Tecidos",
-      description: "Linho Importado Bege",
-      balance: "120 Metros",
-      location: "Corredor A, Prat 3",
-    ),
-    InventoryItem(
-      code: "ESPUMA-D28",
-      category: "Espumas",
-      description: "Espuma Flexível D28",
-      balance: "15 Unid.",
-      location: "Corredor C, Chão",
-      isLowStock: true,
-    ),
-    InventoryItem(
-      code: "ARTIC-METAL",
-      category: "Ferragens",
-      description: "Articulador de Sofá-cama Premium",
-      balance: "58 Kits",
-      location: "Corredor B, Prat 1",
-    ),
-  ];
+  List<InventoryItem> _items = [];
+  ProviderStatus _status = ProviderStatus.idle;
+  String? _errorMessage;
+  String _search = '';
+  String? _categoryFilter;
 
-  List<InventoryItem> get items => List.unmodifiable(_items);
+  // ─── Getters ───────────────────────────────────────────────────────────────
 
-  void addItem(InventoryItem item) {
+  ProviderStatus get status => _status;
+  String? get errorMessage => _errorMessage;
+  bool get isLoading => _status == ProviderStatus.loading;
+
+  List<InventoryItem> get items {
+    var list = List<InventoryItem>.from(_items);
+    if (_categoryFilter != null) {
+      list = list.where((i) => i.category == _categoryFilter).toList();
+    }
+    if (_search.isNotEmpty) {
+      final q = _search.toLowerCase();
+      list = list
+          .where((i) =>
+              i.code.toLowerCase().contains(q) ||
+              i.description.toLowerCase().contains(q) ||
+              i.location.toLowerCase().contains(q))
+          .toList();
+    }
+    return List.unmodifiable(list);
+  }
+
+  List<InventoryItem> get lowStockItems =>
+      _items.where((i) => i.isLowStock).toList();
+
+  double get totalStockValue =>
+      _items.fold(0.0, (sum, i) => sum + i.totalValue);
+
+  int get totalItems => _items.length;
+
+  // ─── Filtros ───────────────────────────────────────────────────────────────
+
+  void setSearch(String query) {
+    _search = query;
+    notifyListeners();
+  }
+
+  void setCategoryFilter(String? category) {
+    _categoryFilter = category;
+    notifyListeners();
+  }
+
+  // ─── Dados mock para uso offline / fallback ────────────────────────────────
+
+  void _loadMockData() {
+    _items = [
+      const InventoryItem(
+        code: 'LINHO-BEGE',
+        category: 'Tecidos',
+        description: 'Linho Importado Bege',
+        qty: 120,
+        unit: 'Metros',
+        cost: 28.50,
+        location: 'Corredor A, Prat 3',
+        minimumStock: 20,
+        supplier: 'Textil SP',
+      ),
+      const InventoryItem(
+        code: 'ESPUMA-D28',
+        category: 'Espumas',
+        description: 'Espuma Flexível D28',
+        qty: 3,
+        unit: 'Unid.',
+        cost: 145.00,
+        location: 'Corredor C, Chão',
+        minimumStock: 5,
+        supplier: 'Espumados Brasil',
+      ),
+      const InventoryItem(
+        code: 'ARTIC-METAL',
+        category: 'Ferragens',
+        description: 'Articulador de Sofá-cama Premium',
+        qty: 58,
+        unit: 'Kits',
+        cost: 89.90,
+        location: 'Corredor B, Prat 1',
+        minimumStock: 10,
+        supplier: 'MetalParts BR',
+      ),
+    ];
+  }
+
+  // ─── API Actions ───────────────────────────────────────────────────────────
+
+  Future<void> loadFromApi() async {
+    _status = ProviderStatus.loading;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      final data = await ApiService.instance.getInventory(
+        category: _categoryFilter,
+        search: _search.isEmpty ? null : _search,
+      );
+      _items = data
+          .map((e) => InventoryItem.fromJson(e as Map<String, dynamic>))
+          .toList();
+      _status = ProviderStatus.idle;
+    } catch (_) {
+      // Fallback para mock se API indisponível
+      _loadMockData();
+      _status = ProviderStatus.idle;
+    }
+    notifyListeners();
+  }
+
+  Future<void> addItem(InventoryItem item) async {
+    try {
+      await ApiService.instance.addInventoryItem(item.toJson());
+    } catch (_) {
+      // offline: adiciona localmente, sync depois
+    }
     _items.add(item);
     notifyListeners();
   }
 
-  void removeItem(String code) {
-    _items.removeWhere((i) => i.code == code);
+  Future<void> updateBalance(
+      String code, double delta, String reason) async {
+    final idx = _items.indexWhere(
+        (i) => i.code.toUpperCase() == code.toUpperCase());
+    if (idx == -1) return;
+
+    final updated = _items[idx].copyWith(
+      qty: (_items[idx].qty + delta).clamp(0.0, double.infinity),
+    );
+    _items[idx] = updated;
     notifyListeners();
+
+    try {
+      await ApiService.instance.updateInventoryBalance(code, delta, reason);
+    } catch (_) {
+      // offline: será sincronizado pelo OfflineSyncService
+    }
   }
 
-  bool exists(String code) {
-    return _items.any((i) => i.code.toUpperCase() == code.toUpperCase());
+  Future<void> removeItem(String code) async {
+    _items.removeWhere(
+        (i) => i.code.toUpperCase() == code.toUpperCase());
+    notifyListeners();
+    try {
+      await ApiService.instance.deleteInventoryItem(code);
+    } catch (_) {}
   }
+
+  bool exists(String code) =>
+      _items.any((i) => i.code.toUpperCase() == code.toUpperCase());
+
+  InventoryItem? findByCode(String code) =>
+      _items.cast<InventoryItem?>().firstWhere(
+            (i) => i?.code.toUpperCase() == code.toUpperCase(),
+            orElse: () => null,
+          );
 }

--- a/frontend/lib/core/providers/user_provider.dart
+++ b/frontend/lib/core/providers/user_provider.dart
@@ -1,20 +1,93 @@
+// UserProvider refatorado — JWT claims + token lifecycle
+import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/user_model.dart';
+import '../services/api_service.dart';
 
 class UserProvider with ChangeNotifier {
-  String _adminName = 'Toni-Sil';
-  String _companyName = 'S.F.C.P.C';
-  String _profileImageUrl = 'https://ui-avatars.com/api/?name=Admin&background=00BCD4&color=fff';
+  UserModel _user = UserModel.guest();
+  bool _isAuthenticated = false;
 
-  String get adminName => _adminName;
-  String get companyName => _companyName;
-  String get profileImageUrl => _profileImageUrl;
+  UserModel get user => _user;
+  bool get isAuthenticated => _isAuthenticated;
 
-  void updateProfile(String name, String company, {String? imageUrl}) {
-    _adminName = name;
-    _companyName = company;
-    if (imageUrl != null) {
-      _profileImageUrl = imageUrl;
+  // Compat com código existente
+  String get adminName => _user.name;
+  String get companyName => _user.company;
+  String get profileImageUrl =>
+      _user.profileImageUrl ??
+      'https://ui-avatars.com/api/?name=${Uri.encodeComponent(_user.name)}&background=00BCD4&color=fff';
+  String get tenantId => _user.tenantId;
+  String get role => _user.role;
+
+  /// Inicializa lendo token salvo do SharedPreferences
+  Future<void> init() async {
+    await ApiService.instance.init();
+    if (ApiService.instance.hasToken) {
+      final prefs = await SharedPreferences.getInstance();
+      final userJson = prefs.getString('user_data');
+      if (userJson != null) {
+        _user = UserModel.fromJwtClaims(
+            jsonDecode(userJson) as Map<String, dynamic>);
+        _isAuthenticated = true;
+        notifyListeners();
+      }
     }
+  }
+
+  /// Login via API
+  Future<bool> login(String email, String password) async {
+    try {
+      final res = await ApiService.instance.login(email, password);
+      final token = res['access_token'] as String;
+      await ApiService.instance.setToken(token);
+
+      // Decodifica payload do JWT (sem verificação — apenas claims)
+      final parts = token.split('.');
+      if (parts.length == 3) {
+        final payload = utf8.decode(
+            base64Url.decode(base64Url.normalize(parts[1])));
+        final claims = jsonDecode(payload) as Map<String, dynamic>;
+        _user = UserModel.fromJwtClaims(claims);
+
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setString('user_data', jsonEncode(claims));
+      }
+
+      _isAuthenticated = true;
+      notifyListeners();
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Logout — limpa JWT e dados locais
+  Future<void> logout() async {
+    await ApiService.instance.clearToken();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove('user_data');
+    _user = UserModel.guest();
+    _isAuthenticated = false;
     notifyListeners();
+  }
+
+  /// Atualização manual de perfil (Settings)
+  Future<void> updateProfile(String name, String company,
+      {String? imageUrl}) async {
+    _user = UserModel(
+      id: _user.id,
+      name: name,
+      company: company,
+      role: _user.role,
+      tenantId: _user.tenantId,
+      profileImageUrl: imageUrl ?? _user.profileImageUrl,
+    );
+    notifyListeners();
+
+    // Persiste localmente
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('user_data', jsonEncode(_user.toJson()));
   }
 }

--- a/frontend/lib/core/services/api_service.dart
+++ b/frontend/lib/core/services/api_service.dart
@@ -1,0 +1,171 @@
+// ApiService — singleton HTTP com JWT interceptor e baseUrl configurável
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ApiException implements Exception {
+  final int statusCode;
+  final String message;
+  const ApiException(this.statusCode, this.message);
+  @override
+  String toString() => 'ApiException($statusCode): $message';
+}
+
+class ApiService {
+  ApiService._();
+  static final ApiService instance = ApiService._();
+
+  static const _baseUrlKey = 'api_base_url';
+  static const _tokenKey = 'jwt_token';
+  static const _defaultBase = 'http://localhost:8000';
+
+  String _baseUrl = _defaultBase;
+  String? _token;
+
+  /// Carrega baseUrl e token salvos
+  Future<void> init() async {
+    final prefs = await SharedPreferences.getInstance();
+    _baseUrl = prefs.getString(_baseUrlKey) ?? _defaultBase;
+    _token = prefs.getString(_tokenKey);
+  }
+
+  /// Atualiza a URL base da API (salva no SharedPreferences)
+  Future<void> setBaseUrl(String url) async {
+    _baseUrl = url.endsWith('/') ? url.substring(0, url.length - 1) : url;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_baseUrlKey, _baseUrl);
+  }
+
+  String get baseUrl => _baseUrl;
+  bool get hasToken => _token != null && _token!.isNotEmpty;
+
+  /// Salva o JWT após login
+  Future<void> setToken(String token) async {
+    _token = token;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_tokenKey, token);
+  }
+
+  /// Limpa o JWT (logout)
+  Future<void> clearToken() async {
+    _token = null;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_tokenKey);
+  }
+
+  /// Headers padrão com Authorization Bearer
+  Map<String, String> get _headers => {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        if (_token != null) 'Authorization': 'Bearer $_token',
+      };
+
+  Uri _uri(String path, [Map<String, String>? params]) {
+    final uri = Uri.parse('$_baseUrl$path');
+    return params != null ? uri.replace(queryParameters: params) : uri;
+  }
+
+  Map<String, dynamic> _parse(http.Response res) {
+    if (res.statusCode >= 200 && res.statusCode < 300) {
+      return jsonDecode(res.body) as Map<String, dynamic>;
+    }
+    throw ApiException(res.statusCode,
+        (jsonDecode(res.body) as Map?)?['detail']?.toString() ?? res.body);
+  }
+
+  List<dynamic> _parseList(http.Response res) {
+    if (res.statusCode >= 200 && res.statusCode < 300) {
+      final body = jsonDecode(res.body);
+      return body is List ? body : (body['items'] as List? ?? []);
+    }
+    throw ApiException(res.statusCode,
+        (jsonDecode(res.body) as Map?)?['detail']?.toString() ?? res.body);
+  }
+
+  // ─── INVENTORY ─────────────────────────────────────────────────────────────
+
+  Future<List<dynamic>> getInventory({String? category, String? search}) async {
+    final params = <String, String>{};
+    if (category != null) params['category'] = category;
+    if (search != null && search.isNotEmpty) params['search'] = search;
+    final res = await http.get(_uri('/api/v1/inventory', params), headers: _headers);
+    return _parseList(res);
+  }
+
+  Future<Map<String, dynamic>> addInventoryItem(Map<String, dynamic> item) async {
+    final res = await http.post(_uri('/api/v1/inventory'),
+        headers: _headers, body: jsonEncode(item));
+    return _parse(res);
+  }
+
+  Future<Map<String, dynamic>> updateInventoryBalance(
+      String code, double delta, String reason) async {
+    final res = await http.patch(
+      _uri('/api/v1/inventory/$code/balance'),
+      headers: _headers,
+      body: jsonEncode({'delta': delta, 'reason': reason}),
+    );
+    return _parse(res);
+  }
+
+  Future<void> deleteInventoryItem(String code) async {
+    final res =
+        await http.delete(_uri('/api/v1/inventory/$code'), headers: _headers);
+    if (res.statusCode != 204 && res.statusCode != 200) {
+      throw ApiException(res.statusCode, 'Falha ao deletar item');
+    }
+  }
+
+  // ─── AGENT ─────────────────────────────────────────────────────────────────
+
+  Future<Map<String, dynamic>> sendAgentMessage(String message,
+      {String? context}) async {
+    final res = await http.post(
+      _uri('/api/v1/agent/chat'),
+      headers: _headers,
+      body: jsonEncode({
+        'message': message,
+        if (context != null) 'context': context,
+      }),
+    );
+    return _parse(res);
+  }
+
+  // ─── FINANCIAL ─────────────────────────────────────────────────────────────
+
+  Future<Map<String, dynamic>> getFinancialSummary() async {
+    final res =
+        await http.get(_uri('/api/v1/financial/summary'), headers: _headers);
+    return _parse(res);
+  }
+
+  Future<List<dynamic>> getTransactions(
+      {String? period, int page = 1}) async {
+    final res = await http.get(
+      _uri('/api/v1/financial/transactions',
+          {'period': period ?? '30d', 'page': page.toString()}),
+      headers: _headers,
+    );
+    return _parseList(res);
+  }
+
+  // ─── AUTH ──────────────────────────────────────────────────────────────────
+
+  Future<Map<String, dynamic>> login(
+      String email, String password) async {
+    final res = await http.post(
+      _uri('/api/v1/auth/login'),
+      headers: _headers,
+      body: jsonEncode({'email': email, 'password': password}),
+    );
+    return _parse(res);
+  }
+
+  // ─── FORECAST ──────────────────────────────────────────────────────────────
+
+  Future<Map<String, dynamic>> getForecast(String itemCode) async {
+    final res = await http.get(
+        _uri('/api/v1/forecast/$itemCode'), headers: _headers);
+    return _parse(res);
+  }
+}

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,25 +1,48 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'presentation/theme/app_theme.dart';
 import 'presentation/screens/home_screen.dart';
+import 'presentation/screens/onboarding_screen.dart';
+import 'core/providers/user_provider.dart';
+import 'core/providers/operational_provider.dart';
+import 'core/services/offline_sync_service.dart';
 
-import 'package:frontend/core/providers/user_provider.dart';
-import 'package:frontend/core/providers/operational_provider.dart';
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
 
-void main() {
+  // Inicializa serviços base
+  await OfflineSyncService.init();
+
+  // Inicializa providers com dados persistidos
+  final userProvider = UserProvider();
+  await userProvider.init();
+
+  final prefs = await SharedPreferences.getInstance();
+  final onboardingDone = prefs.getBool('onboarding_done') ?? false;
+
   runApp(
     MultiProvider(
       providers: [
-        ChangeNotifierProvider(create: (_) => UserProvider()),
+        ChangeNotifierProvider.value(value: userProvider),
         ChangeNotifierProvider(create: (_) => OperationalProvider()),
       ],
-      child: const SFCpcApp(),
+      child: SFCpcApp(
+        showOnboarding: !onboardingDone,
+        isAuthenticated: userProvider.isAuthenticated,
+      ),
     ),
   );
 }
 
 class SFCpcApp extends StatelessWidget {
-  const SFCpcApp({super.key});
+  final bool showOnboarding;
+  final bool isAuthenticated;
+  const SFCpcApp({
+    super.key,
+    required this.showOnboarding,
+    required this.isAuthenticated,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -27,7 +50,14 @@ class SFCpcApp extends StatelessWidget {
       title: 'S.F.C.P.C AI',
       debugShowCheckedModeBanner: false,
       theme: AppTheme.darkTheme,
-      home: const HomeScreen(),
+      home: showOnboarding
+          ? OnboardingScreen(
+              onFinished: () => Navigator.pushReplacementNamed(
+                  context, '/home'))
+          : const HomeScreen(),
+      routes: {
+        '/home': (_) => const HomeScreen(),
+      },
     );
   }
 }


### PR DESCRIPTION
## PR #A — Fundação

> **Merge este PR antes de qualquer outro.** Os PR #B, #C e #D dependem desta base.

---

## Arquivos alterados (6)

### `core/models/inventory_item.dart` — NOVO
- `balance: String` substituído por `qty: double` + `unit: String` + `cost: double`
- `minimumStock: double` — `isLowStock` calculado automaticamente (`qty <= minimumStock`)
- `balanceLabel` getter formata exibição (`"120 Metros"`)
- `totalValue` getter (`qty * cost`) — habilita KPIs financeiros reais
- `toJson()` / `fromJson()` — serialização para API e cache offline
- `copyWith()` completo

### `core/models/user_model.dart` — NOVO
- `UserModel` com campos: `id`, `name`, `company`, `role`, `tenantId`, `profileImageUrl`
- `fromJwtClaims()` — constrói modelo direto dos claims do JWT
- `UserModel.guest()` factory para estado não autenticado
- `isAdmin` getter

### `core/services/api_service.dart` — NOVO
- Singleton `ApiService.instance`
- `baseUrl` configurável via `setBaseUrl()` — salvo no `SharedPreferences`
- JWT `Bearer` header injetado automaticamente em todas as requisições
- `setToken()` / `clearToken()` — lifecycle completo
- Métodos cobertos:
  - `getInventory()`, `addInventoryItem()`, `updateInventoryBalance()`, `deleteInventoryItem()`
  - `sendAgentMessage()` — prepara PR #B
  - `getFinancialSummary()`, `getTransactions()` — prepara PR #C
  - `login()` — prepara autenticação
  - `getForecast()` — integração forecast real

### `core/providers/operational_provider.dart` — REFATORADO
- Usa `InventoryItem` do model separado
- `ProviderStatus` enum (idle / loading / error)
- `loadFromApi()` — carrega da API com fallback para mock offline
- `updateBalance(code, delta, reason)` — entrada/saída real de estoque
- `setSearch()` / `setCategoryFilter()` — filtros reativos na lista
- `totalStockValue`, `lowStockItems`, `totalItems` getters para KPIs
- `findByCode()` helper para Scanner e Agent

### `core/providers/user_provider.dart` — REFATORADO
- Usa `UserModel` + `ApiService`
- `init()` — restaura sessão do `SharedPreferences` no boot
- `login()` — chama API, salva token, decodifica JWT claims
- `logout()` — limpa JWT e dados locais (corrige bug crítico do Settings)
- `tenantId` e `role` getters vêm do JWT real
- Mantém `adminName`, `companyName`, `profileImageUrl` para compatibilidade retroativa

### `main.dart` — ATUALIZADO
- `await userProvider.init()` antes do `runApp`
- `ChangeNotifierProvider.value` com instância pré-inicializada
- `isAuthenticated` passado para `SFCpcApp`
- Rota `/home` registrada como named route

---

## O que este PR NÃO toca
- Nenhuma tela alterada (UI intacta)
- Sem breaking changes visuais
- Dados mock mantidos como fallback offline

## Próximo passo após merge
→ **PR #B** — AgentScreen: ChatMessage model + HTTP real + Scanner integrado