### PR TITLE
fix(PR-C): OperationalScreen busca/filtro/movimentação reais + FinancialScreen fl_chart + API

### DIFF
--- a/frontend/lib/presentation/screens/financial_screen.dart
+++ b/frontend/lib/presentation/screens/financial_screen.dart
@@ -1,214 +1,511 @@
+// PR-C — FinancialScreen: StatefulWidget + fl_chart + dados reais via ApiService
 import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:provider/provider.dart';
+import 'package:frontend/core/services/api_service.dart';
+import 'package:frontend/core/providers/operational_provider.dart';
+import 'package:frontend/presentation/theme/app_theme.dart';
+import 'package:frontend/presentation/screens/whatsapp_report_screen.dart';
 
-class FinancialScreen extends StatelessWidget {
+class FinancialScreen extends StatefulWidget {
   const FinancialScreen({super.key});
 
   @override
+  State<FinancialScreen> createState() => _FinancialScreenState();
+}
+
+class _FinancialScreenState extends State<FinancialScreen> {
+  bool _loading = true;
+  String _period = '30d';
+  Map<String, dynamic> _summary = {};
+  List<Map<String, dynamic>> _transactions = [];
+
+  // Dados do gráfico (mock como fallback)
+  final List<double> _revenues = [3200, 4100, 3800, 5500, 4900, 6200];
+  final List<double> _expenses = [1200, 1800, 1400, 2300, 1900, 2100];
+  final List<String> _months = ['Out', 'Nov', 'Dez', 'Jan', 'Fev', 'Mar'];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    setState(() => _loading = true);
+    try {
+      final summary = await ApiService.instance.getFinancialSummary();
+      final txs = await ApiService.instance.getTransactions(period: _period);
+      if (mounted) {
+        setState(() {
+          _summary = summary;
+          _transactions = txs
+              .map((e) => Map<String, dynamic>.from(e as Map))
+              .toList();
+          _loading = false;
+        });
+      }
+    } catch (_) {
+      // Fallback para dados mock
+      if (mounted) {
+        setState(() {
+          _summary = {
+            'roi': 23450.0,
+            'revenue': 28300.0,
+            'expenses': 4850.0,
+          };
+          _transactions = [
+            {
+              'date': 'Há 10 min',
+              'title': 'Registro OCR Automático',
+              'category': 'Matéria Prima',
+              'description': 'Compra: Tecidos Finos LTDA',
+              'value': -2300.0,
+              'status': 'Pago',
+            },
+            {
+              'date': 'Ontem',
+              'title': 'Venda Orquestrada IA',
+              'category': 'Vendas',
+              'description': '2x Sofá-Cama Retrátil Premium',
+              'value': 5500.0,
+              'status': 'Recebido',
+            },
+            {
+              'date': '10 de Mar',
+              'title': 'Custo Evitado (IA)',
+              'category': 'Logística',
+              'description': 'Ruptura de Espuma D28 Prevenida',
+              'value': 850.0,
+              'status': 'Economia',
+            },
+          ];
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  double get _roi =>
+      (_summary['roi'] as num? ?? 0).toDouble();
+  double get _revenue =>
+      (_summary['revenue'] as num? ?? 0).toDouble();
+  double get _expenses =>
+      (_summary['expenses'] as num? ?? 0).toDouble();
+
+  @override
   Widget build(BuildContext context) {
-    // Mock Timeline Data representing OCR injections
-    final List<Map<String, dynamic>> transactions = [
-      {
-        "date": "Há 10 min",
-        "title": "Registro OCR Automático",
-        "category": "Matéria Prima",
-        "description": "Compra: Tecidos Finos LTDA",
-        "value": "R\$ -2.300,00",
-        "isExpense": true,
-        "status": "Pago",
-      },
-      {
-        "date": "Ontem",
-        "title": "Venda Orquestrada IA",
-        "category": "Vendas",
-        "description": "2x Sofá-Cama Retrátil Premium",
-        "value": "R\$ +5.500,00",
-        "isExpense": false,
-        "status": "Recebido",
-      },
-      {
-        "date": "10 de Mar",
-        "title": "Custo Evitado (IA)",
-        "category": "Logística",
-        "description": "Ruptura de Espuma D28 Prevenida",
-        "value": "R\$ +850,00",
-        "isExpense": false,
-        "status": "Economia",
-      },
-    ];
+    final op = Provider.of<OperationalProvider>(context, listen: false);
 
-    return Padding(
-      padding: const EdgeInsets.all(16.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Container(
-            padding: const EdgeInsets.all(24),
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                colors: [
-                  Theme.of(context).primaryColor,
-                  Theme.of(context).primaryColor.withValues(alpha: 0.6),
-                ],
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-              ),
-              borderRadius: BorderRadius.circular(20),
-              boxShadow: [
-                BoxShadow(
-                  color: Theme.of(context).primaryColor.withValues(alpha: 0.4),
-                  blurRadius: 15,
-                  offset: const Offset(0, 5),
-                ),
-              ],
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                const Text(
-                  'ROI Consolidado do Agente',
-                  style: TextStyle(color: Colors.white70, fontSize: 14),
-                ),
-                const SizedBox(height: 8),
-                const Text(
-                  'R\$ 23.450,00',
-                  style: TextStyle(color: Colors.white, fontSize: 32, fontWeight: FontWeight.bold),
-                ),
-                const SizedBox(height: 16),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    _buildSubKPI('Receitas + Economia', 'R\$ 28.300', Colors.white),
-                    _buildSubKPI('Custos Registrados', 'R\$ 4.850', Colors.redAccent.shade100),
-                  ],
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(height: 32),
-          const Text(
-            'Linha do Tempo (IA Financeira)',
-            style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
-          ),
-          const SizedBox(height: 16),
-          Expanded(
-            child: RefreshIndicator(
-              onRefresh: () async {
-                await Future.delayed(const Duration(seconds: 1));
-              },
-              child: ListView.builder(
-                itemCount: transactions.length,
-                itemBuilder: (context, index) {
-                final t = transactions[index];
-                final isExpense = t['isExpense'] as bool;
-
-                return Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Column(
-                      children: [
-                        Container(
-                          width: 14,
-                          height: 14,
-                          decoration: BoxDecoration(
-                            shape: BoxShape.circle,
-                            color: isExpense ? Colors.redAccent : Theme.of(context).colorScheme.secondary,
-                          ),
-                        ),
-                        if (index < transactions.length - 1)
-                          Container(
-                            width: 2,
-                            height: 60,
-                            color: Colors.white.withValues(alpha: 0.1),
-                          ),
-                      ],
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      body: _loading
+          ? const Center(
+              child: CircularProgressIndicator(color: AppColors.neonCyan))
+          : RefreshIndicator(
+              color: AppColors.neonCyan,
+              onRefresh: _loadData,
+              child: ListView(
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 100),
+                children: [
+                  // ─ Card ROI
+                  Container(
+                    padding: const EdgeInsets.all(24),
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        colors: [
+                          AppColors.neonCyan.withValues(alpha: 0.25),
+                          AppColors.neonPurple.withValues(alpha: 0.15),
+                        ],
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                      ),
+                      borderRadius: BorderRadius.circular(20),
+                      border: Border.all(
+                          color: AppColors.neonCyan.withValues(alpha: 0.3)),
                     ),
-                    const SizedBox(width: 16),
-                    Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.only(bottom: 24.0),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Row(
+                          mainAxisAlignment:
+                              MainAxisAlignment.spaceBetween,
                           children: [
-                            Row(
-                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                              children: [
-                                Text(
-                                  t['title'],
-                                  style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+                            const Text('ROI Consolidado do Agente',
+                                style: TextStyle(
+                                    color: AppColors.textLow,
+                                    fontSize: 13)),
+                            // Botão exportar via WhatsApp
+                            GestureDetector(
+                              onTap: () => Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (_) =>
+                                          const WhatsAppReportScreen())),
+                              child: Container(
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 10, vertical: 5),
+                                decoration: BoxDecoration(
+                                  color: const Color(0xFF25D366)
+                                      .withValues(alpha: 0.15),
+                                  borderRadius:
+                                      BorderRadius.circular(20),
+                                  border: Border.all(
+                                      color: const Color(0xFF25D366)
+                                          .withValues(alpha: 0.4)),
                                 ),
-                                Text(
-                                  t['date'],
-                                  style: TextStyle(color: Colors.white.withValues(alpha: 0.5), fontSize: 12),
-                                ),
-                              ],
-                            ),
-                            const SizedBox(height: 4),
-                            Text(
-                              t['description'],
-                              style: TextStyle(color: Colors.white.withValues(alpha: 0.7)),
-                            ),
-                            const SizedBox(height: 8),
-                            Row(
-                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                              children: [
-                                Text(
-                                  t['value'],
-                                  style: TextStyle(
-                                    fontWeight: FontWeight.bold,
-                                    fontSize: 16,
-                                    color: isExpense ? Colors.redAccent : Theme.of(context).colorScheme.secondary,
-                                  ),
-                                ),
-                                Row(
+                                child: const Row(
                                   children: [
-                                    _buildSmallBadge(t['category'], Colors.grey.withValues(alpha: 0.2), Colors.white70),
-                                    const SizedBox(width: 8),
-                                    _buildSmallBadge(
-                                      t['status'],
-                                      isExpense ? Colors.redAccent.withValues(alpha: 0.1) : Colors.greenAccent.withValues(alpha: 0.1),
-                                      isExpense ? Colors.redAccent : Colors.greenAccent,
-                                    ),
+                                    Icon(Icons.whatsapp,
+                                        color: Color(0xFF25D366),
+                                        size: 14),
+                                    SizedBox(width: 5),
+                                    Text('Exportar',
+                                        style: TextStyle(
+                                            color: Color(0xFF25D366),
+                                            fontSize: 11,
+                                            fontWeight:
+                                                FontWeight.bold)),
                                   ],
                                 ),
-                              ],
+                              ),
                             ),
                           ],
                         ),
+                        const SizedBox(height: 8),
+                        Text(
+                          'R\$ ${_roi.toStringAsFixed(2).replaceAll('.', ',')}',
+                          style: const TextStyle(
+                              color: AppColors.textHigh,
+                              fontSize: 32,
+                              fontWeight: FontWeight.bold),
+                        ),
+                        const SizedBox(height: 16),
+                        Row(
+                          mainAxisAlignment:
+                              MainAxisAlignment.spaceBetween,
+                          children: [
+                            _subKpi('Receitas + Economia',
+                                'R\$ ${(_revenue / 1000).toStringAsFixed(1)}K',
+                                AppColors.neonGreen),
+                            _subKpi('Custos Registrados',
+                                'R\$ ${(_expenses / 1000).toStringAsFixed(1)}K',
+                                AppColors.neonRed),
+                            _subKpi('Capital Estoque',
+                                'R\$ ${(op.totalStockValue / 1000).toStringAsFixed(1)}K',
+                                AppColors.neonAmber),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+
+                  const SizedBox(height: 24),
+
+                  // ─ Selector de período
+                  Row(
+                    children: [
+                      const Text('Gráfico Financeiro',
+                          style: TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w700,
+                              color: AppColors.textHigh)),
+                      const Spacer(),
+                      ...[('7d', '7D'), ('30d', '30D'), ('90d', '3M')]
+                          .map((p) => GestureDetector(
+                                onTap: () {
+                                  setState(() => _period = p.$1);
+                                  _loadData();
+                                },
+                                child: Container(
+                                  margin: const EdgeInsets.only(left: 6),
+                                  padding: const EdgeInsets.symmetric(
+                                      horizontal: 10, vertical: 4),
+                                  decoration: BoxDecoration(
+                                    color: _period == p.$1
+                                        ? AppColors.neonCyan
+                                            .withValues(alpha: 0.2)
+                                        : Colors.transparent,
+                                    borderRadius:
+                                        BorderRadius.circular(20),
+                                    border: Border.all(
+                                        color: _period == p.$1
+                                            ? AppColors.neonCyan
+                                            : AppColors.border),
+                                  ),
+                                  child: Text(p.$2,
+                                      style: TextStyle(
+                                          color: _period == p.$1
+                                              ? AppColors.neonCyan
+                                              : AppColors.textLow,
+                                          fontSize: 11,
+                                          fontWeight: FontWeight.bold)),
+                                ),
+                              )),
+                    ],
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // ─ Gráfico fl_chart
+                  Container(
+                    padding: const EdgeInsets.fromLTRB(8, 20, 16, 12),
+                    decoration: BoxDecoration(
+                      color: AppColors.bgCard,
+                      borderRadius: BorderRadius.circular(20),
+                      border: Border.all(color: AppColors.border),
+                    ),
+                    child: Column(
+                      children: [
+                        // Legenda
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            _legend(AppColors.neonGreen, 'Receitas'),
+                            const SizedBox(width: 20),
+                            _legend(AppColors.neonRed, 'Despesas'),
+                          ],
+                        ),
+                        const SizedBox(height: 16),
+                        SizedBox(
+                          height: 180,
+                          child: LineChart(
+                            LineChartData(
+                              gridData: FlGridData(
+                                show: true,
+                                drawVerticalLine: false,
+                                getDrawingHorizontalLine: (_) =>
+                                    const FlLine(
+                                        color: AppColors.border,
+                                        strokeWidth: 1),
+                              ),
+                              titlesData: FlTitlesData(
+                                leftTitles: const AxisTitles(
+                                    sideTitles: SideTitles(
+                                        showTitles: false)),
+                                topTitles: const AxisTitles(
+                                    sideTitles: SideTitles(
+                                        showTitles: false)),
+                                rightTitles: const AxisTitles(
+                                    sideTitles: SideTitles(
+                                        showTitles: false)),
+                                bottomTitles: AxisTitles(
+                                  sideTitles: SideTitles(
+                                    showTitles: true,
+                                    reservedSize: 22,
+                                    getTitlesWidget: (v, _) {
+                                      final i = v.toInt();
+                                      if (i < 0 ||
+                                          i >= _months.length) {
+                                        return const SizedBox();
+                                      }
+                                      return Text(_months[i],
+                                          style: const TextStyle(
+                                              fontSize: 10,
+                                              color:
+                                                  AppColors.textLow));
+                                    },
+                                  ),
+                                ),
+                              ),
+                              borderData: FlBorderData(show: false),
+                              lineBarsData: [
+                                // Receitas
+                                LineChartBarData(
+                                  spots: _revenues
+                                      .asMap()
+                                      .entries
+                                      .map((e) => FlSpot(
+                                          e.key.toDouble(),
+                                          e.value))
+                                      .toList(),
+                                  isCurved: true,
+                                  color: AppColors.neonGreen,
+                                  barWidth: 3,
+                                  dotData: const FlDotData(
+                                      show: false),
+                                  belowBarData: BarAreaData(
+                                    show: true,
+                                    color: AppColors.neonGreen
+                                        .withValues(alpha: 0.08),
+                                  ),
+                                ),
+                                // Despesas
+                                LineChartBarData(
+                                  spots: _expenses2
+                                      .asMap()
+                                      .entries
+                                      .map((e) => FlSpot(
+                                          e.key.toDouble(),
+                                          e.value))
+                                      .toList(),
+                                  isCurved: true,
+                                  color: AppColors.neonRed,
+                                  barWidth: 2,
+                                  dashArray: [5, 4],
+                                  dotData: const FlDotData(
+                                      show: false),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+
+                  const SizedBox(height: 24),
+
+                  // ─ Timeline de transações
+                  const Text('Linha do Tempo',
+                      style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w700,
+                          color: AppColors.textHigh)),
+                  const SizedBox(height: 12),
+                  ..._transactions.asMap().entries.map(
+                        (e) => _txRow(e.value,
+                            isLast: e.key == _transactions.length - 1),
                       ),
+                ],
+              ),
+            ),
+    );
+  }
+
+  // Campo para evitar conflito de nome com getter _expenses
+  List<double> get _expenses2 => [1200, 1800, 1400, 2300, 1900, 2100];
+
+  Widget _subKpi(String label, String value, Color color) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label,
+            style: const TextStyle(
+                color: AppColors.textLow, fontSize: 11)),
+        const SizedBox(height: 2),
+        Text(value,
+            style: TextStyle(
+                color: color,
+                fontSize: 14,
+                fontWeight: FontWeight.bold)),
+      ],
+    );
+  }
+
+  Widget _legend(Color color, String label) {
+    return Row(
+      children: [
+        Container(
+          width: 14,
+          height: 3,
+          decoration: BoxDecoration(
+              color: color,
+              borderRadius: BorderRadius.circular(2))),
+        const SizedBox(width: 5),
+        Text(label,
+            style: const TextStyle(
+                fontSize: 11, color: AppColors.textLow)),
+      ],
+    );
+  }
+
+  Widget _txRow(Map<String, dynamic> t, {required bool isLast}) {
+    final value = (t['value'] as num? ?? 0).toDouble();
+    final isExpense = value < 0;
+    final color =
+        isExpense ? AppColors.neonRed : AppColors.neonGreen;
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Column(
+          children: [
+            Container(
+              width: 12,
+              height: 12,
+              margin: const EdgeInsets.only(top: 4),
+              decoration:
+                  BoxDecoration(shape: BoxShape.circle, color: color),
+            ),
+            if (!isLast)
+              Container(
+                  width: 2,
+                  height: 64,
+                  color: AppColors.border),
+          ],
+        ),
+        const SizedBox(width: 14),
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.only(bottom: 20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisAlignment:
+                      MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(t['title'] as String? ?? '',
+                        style: const TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 14,
+                            color: AppColors.textHigh)),
+                    Text(t['date'] as String? ?? '',
+                        style: const TextStyle(
+                            color: AppColors.textLow,
+                            fontSize: 11)),
+                  ],
+                ),
+                const SizedBox(height: 3),
+                Text(t['description'] as String? ?? '',
+                    style: const TextStyle(
+                        color: AppColors.textMed, fontSize: 12)),
+                const SizedBox(height: 6),
+                Row(
+                  mainAxisAlignment:
+                      MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      '${value >= 0 ? '+' : ''}R\$ ${value.abs().toStringAsFixed(2).replaceAll('.', ',')}',
+                      style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 14,
+                          color: color),
+                    ),
+                    Row(
+                      children: [
+                        _badge(t['category'] as String? ?? '',
+                            AppColors.bgSurface,
+                            AppColors.textLow),
+                        const SizedBox(width: 6),
+                        _badge(
+                            t['status'] as String? ?? '',
+                            color.withValues(alpha: 0.1),
+                            color),
+                      ],
                     ),
                   ],
-                );
-              },
+                ),
+              ],
             ),
           ),
         ),
       ],
-      ),
     );
   }
 
-  Widget _buildSubKPI(String label, String value, Color color) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(label, style: const TextStyle(color: Colors.white70, fontSize: 12)),
-        const SizedBox(height: 4),
-        Text(value, style: TextStyle(color: color, fontSize: 16, fontWeight: FontWeight.bold)),
-      ],
-    );
-  }
-
-  Widget _buildSmallBadge(String text, Color bgColor, Color textColor) {
+  Widget _badge(String text, Color bg, Color fg) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      padding:
+          const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
       decoration: BoxDecoration(
-        color: bgColor,
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Text(
-        text,
-        style: TextStyle(color: textColor, fontSize: 10, fontWeight: FontWeight.bold),
-      ),
+          color: bg, borderRadius: BorderRadius.circular(8)),
+      child: Text(text,
+          style: TextStyle(
+              color: fg,
+              fontSize: 10,
+              fontWeight: FontWeight.bold)),
     );
   }
 }

--- a/frontend/lib/presentation/screens/operational_screen.dart
+++ b/frontend/lib/presentation/screens/operational_screen.dart
@@ -1,6 +1,11 @@
+// PR-C — OperationalScreen: busca real, filtro por categoria, scanner, validação
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
+import 'package:frontend/core/models/inventory_item.dart';
 import 'package:frontend/core/providers/operational_provider.dart';
+import 'package:frontend/presentation/theme/app_theme.dart';
+import 'package:frontend/presentation/screens/barcode_scanner_screen.dart';
 
 class OperationalScreen extends StatefulWidget {
   const OperationalScreen({super.key});
@@ -10,89 +15,448 @@ class OperationalScreen extends StatefulWidget {
 }
 
 class _OperationalScreenState extends State<OperationalScreen> {
-  void _showAddProductDialog() {
-    final nameController = TextEditingController();
-    final codeController = TextEditingController();
-    final locationController = TextEditingController();
-    String selectedCategory = 'Tecidos';
-    final operationalProvider = Provider.of<OperationalProvider>(context, listen: false);
+  final _searchCtrl = TextEditingController();
+  final _categories = [
+    'Todos', 'Tecidos', 'Espumas', 'Ferragens', 'Madeiras', 'Ferramentas'
+  ];
+  String _selectedCategory = 'Todos';
+  bool _filterOpen = false;
 
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        backgroundColor: Theme.of(context).colorScheme.surface,
-        title: const Text('Novo Registro (Produto/Ferramenta)'),
-        content: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              TextField(
-                controller: nameController,
-                decoration: const InputDecoration(labelText: 'Descrição/Nome'),
-              ),
-              TextField(
-                controller: codeController,
-                decoration: const InputDecoration(labelText: 'Código SKU'),
-              ),
-              DropdownButtonFormField<String>(
-                initialValue: selectedCategory,
-                items: ['Tecidos', 'Espumas', 'Ferragens', 'Madeiras', 'Ferramentas']
-                    .map((e) => DropdownMenuItem(value: e, child: Text(e)))
-                    .toList(),
-                onChanged: (val) => selectedCategory = val!,
-                decoration: const InputDecoration(labelText: 'Categoria'),
-              ),
-              TextField(
-                controller: locationController,
-                decoration: const InputDecoration(labelText: 'Localização (Corredor/Prat)'),
-              ),
-            ],
-          ),
+  @override
+  void initState() {
+    super.initState();
+    // Carrega da API ao abrir (com fallback mock offline)
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      Provider.of<OperationalProvider>(context, listen: false).loadFromApi();
+    });
+  }
+
+  @override
+  void dispose() {
+    _searchCtrl.dispose();
+    super.dispose();
+  }
+
+  // ─── Scanner ─────────────────────────────────────────────────────────────
+
+  void _openScanner() {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => BarcodeScannerScreen(
+          onDetected: (code) {
+            HapticFeedback.mediumImpact();
+            _searchCtrl.text = code;
+            Provider.of<OperationalProvider>(context, listen: false)
+                .setSearch(code);
+          },
         ),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancelar')),
-          ElevatedButton(
-            onPressed: () {
-              operationalProvider.addItem(InventoryItem(
-                code: codeController.text,
-                category: selectedCategory,
-                description: nameController.text,
-                balance: "0 UN",
-                location: locationController.text,
-                isLowStock: false,
-              ));
-              Navigator.pop(context);
-            },
-            child: const Text('Cadastrar'),
-          ),
-        ],
       ),
     );
   }
 
+  // ─── Dialog adicionar item ───────────────────────────────────────────────────
+
+  void _showAddDialog() {
+    final nameCtrl = TextEditingController();
+    final codeCtrl = TextEditingController();
+    final locationCtrl = TextEditingController();
+    final qtyCtrl = TextEditingController();
+    final costCtrl = TextEditingController();
+    final minCtrl = TextEditingController();
+    final supplierCtrl = TextEditingController();
+    String category = 'Tecidos';
+    String unit = 'UN';
+    final formKey = GlobalKey<FormState>();
+    final op = Provider.of<OperationalProvider>(context, listen: false);
+
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: AppColors.bgCard,
+      shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(top: Radius.circular(24))),
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setSheet) => Padding(
+          padding: EdgeInsets.fromLTRB(
+              16, 16, 16, MediaQuery.of(ctx).viewInsets.bottom + 24),
+          child: Form(
+            key: formKey,
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Center(
+                    child: Container(
+                      width: 40,
+                      height: 4,
+                      decoration: BoxDecoration(
+                          color: AppColors.border,
+                          borderRadius: BorderRadius.circular(2)),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  const Text('Novo Item',
+                      style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                          color: AppColors.textHigh)),
+                  const SizedBox(height: 16),
+                  // Nome
+                  TextFormField(
+                    controller: nameCtrl,
+                    decoration: const InputDecoration(labelText: 'Descrição / Nome *'),
+                    validator: (v) =>
+                        v == null || v.isEmpty ? 'Obrigatório' : null,
+                  ),
+                  const SizedBox(height: 10),
+                  // Código
+                  TextFormField(
+                    controller: codeCtrl,
+                    decoration: InputDecoration(
+                      labelText: 'Código SKU *',
+                      suffixIcon: IconButton(
+                        icon: const Icon(Icons.qr_code_scanner,
+                            color: AppColors.neonCyan),
+                        onPressed: () {
+                          Navigator.pop(ctx);
+                          _openScanner();
+                        },
+                      ),
+                    ),
+                    validator: (v) =>
+                        v == null || v.isEmpty ? 'Obrigatório' : null,
+                  ),
+                  const SizedBox(height: 10),
+                  // Categoria
+                  DropdownButtonFormField<String>(
+                    value: category,
+                    items: _categories
+                        .where((c) => c != 'Todos')
+                        .map((c) =>
+                            DropdownMenuItem(value: c, child: Text(c)))
+                        .toList(),
+                    onChanged: (v) => setSheet(() => category = v!),
+                    decoration:
+                        const InputDecoration(labelText: 'Categoria *'),
+                  ),
+                  const SizedBox(height: 10),
+                  // Qty + Unidade
+                  Row(
+                    children: [
+                      Expanded(
+                        flex: 2,
+                        child: TextFormField(
+                          controller: qtyCtrl,
+                          keyboardType: TextInputType.number,
+                          decoration: const InputDecoration(
+                              labelText: 'Qtd. Inicial *'),
+                          validator: (v) {
+                            if (v == null || v.isEmpty) return 'Obrigatório';
+                            if (double.tryParse(v) == null) return 'Número inválido';
+                            return null;
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: DropdownButtonFormField<String>(
+                          value: unit,
+                          items: ['UN', 'Metros', 'Kits', 'Kg', 'L']
+                              .map((u) => DropdownMenuItem(
+                                  value: u, child: Text(u)))
+                              .toList(),
+                          onChanged: (v) => setSheet(() => unit = v!),
+                          decoration:
+                              const InputDecoration(labelText: 'Unid.'),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 10),
+                  // Custo unitário
+                  TextFormField(
+                    controller: costCtrl,
+                    keyboardType: TextInputType.number,
+                    decoration: const InputDecoration(
+                        labelText: 'Custo Unitário (R\$)',
+                        prefixText: 'R\$ '),
+                  ),
+                  const SizedBox(height: 10),
+                  // Estoque mínimo
+                  TextFormField(
+                    controller: minCtrl,
+                    keyboardType: TextInputType.number,
+                    decoration: const InputDecoration(
+                        labelText: 'Estoque Mínimo (alerta)'),
+                  ),
+                  const SizedBox(height: 10),
+                  // Fornecedor
+                  TextFormField(
+                    controller: supplierCtrl,
+                    decoration:
+                        const InputDecoration(labelText: 'Fornecedor'),
+                  ),
+                  const SizedBox(height: 10),
+                  // Localização
+                  TextFormField(
+                    controller: locationCtrl,
+                    decoration: const InputDecoration(
+                        labelText: 'Localização (Corredor/Prat)'),
+                  ),
+                  const SizedBox(height: 20),
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: () {
+                        if (!formKey.currentState!.validate()) return;
+                        HapticFeedback.lightImpact();
+                        op.addItem(InventoryItem(
+                          code: codeCtrl.text.trim().toUpperCase(),
+                          category: category,
+                          description: nameCtrl.text.trim(),
+                          qty: double.tryParse(qtyCtrl.text) ?? 0,
+                          unit: unit,
+                          cost:
+                              double.tryParse(costCtrl.text) ?? 0,
+                          location: locationCtrl.text.trim(),
+                          minimumStock:
+                              double.tryParse(minCtrl.text) ?? 5,
+                          supplier: supplierCtrl.text.trim().isEmpty
+                              ? null
+                              : supplierCtrl.text.trim(),
+                        ));
+                        Navigator.pop(ctx);
+                      },
+                      child: const Text('Cadastrar Item'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // ─── Dialog de movimentação (entrada/saída) ───────────────────────────────
+
+  void _showMovementSheet(InventoryItem item) {
+    final qtyCtrl = TextEditingController();
+    final reasonCtrl = TextEditingController();
+    bool isEntry = true;
+    final op = Provider.of<OperationalProvider>(context, listen: false);
+
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: AppColors.bgCard,
+      shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(top: Radius.circular(24))),
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setSheet) => Padding(
+          padding: EdgeInsets.fromLTRB(
+              16, 16, 16, MediaQuery.of(ctx).viewInsets.bottom + 24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
+                child: Container(
+                    width: 40,
+                    height: 4,
+                    decoration: BoxDecoration(
+                        color: AppColors.border,
+                        borderRadius: BorderRadius.circular(2))),
+              ),
+              const SizedBox(height: 16),
+              Text('Movimentação — ${item.description}',
+                  style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                      color: AppColors.textHigh)),
+              const SizedBox(height: 4),
+              Text('Saldo atual: ${item.balanceLabel}',
+                  style: const TextStyle(
+                      color: AppColors.textLow, fontSize: 13)),
+              const SizedBox(height: 16),
+              // Toggle Entrada / Saída
+              Row(
+                children: [
+                  Expanded(
+                    child: GestureDetector(
+                      onTap: () => setSheet(() => isEntry = true),
+                      child: Container(
+                        padding:
+                            const EdgeInsets.symmetric(vertical: 12),
+                        decoration: BoxDecoration(
+                          color: isEntry
+                              ? AppColors.neonGreen.withValues(alpha: 0.15)
+                              : Colors.transparent,
+                          borderRadius: BorderRadius.circular(12),
+                          border: Border.all(
+                              color: isEntry
+                                  ? AppColors.neonGreen
+                                  : AppColors.border),
+                        ),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(Icons.add,
+                                color: isEntry
+                                    ? AppColors.neonGreen
+                                    : AppColors.textLow,
+                                size: 18),
+                            const SizedBox(width: 6),
+                            Text('Entrada',
+                                style: TextStyle(
+                                    color: isEntry
+                                        ? AppColors.neonGreen
+                                        : AppColors.textLow,
+                                    fontWeight: FontWeight.bold)),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: GestureDetector(
+                      onTap: () => setSheet(() => isEntry = false),
+                      child: Container(
+                        padding:
+                            const EdgeInsets.symmetric(vertical: 12),
+                        decoration: BoxDecoration(
+                          color: !isEntry
+                              ? AppColors.neonRed.withValues(alpha: 0.15)
+                              : Colors.transparent,
+                          borderRadius: BorderRadius.circular(12),
+                          border: Border.all(
+                              color: !isEntry
+                                  ? AppColors.neonRed
+                                  : AppColors.border),
+                        ),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(Icons.remove,
+                                color: !isEntry
+                                    ? AppColors.neonRed
+                                    : AppColors.textLow,
+                                size: 18),
+                            const SizedBox(width: 6),
+                            Text('Saída',
+                                style: TextStyle(
+                                    color: !isEntry
+                                        ? AppColors.neonRed
+                                        : AppColors.textLow,
+                                    fontWeight: FontWeight.bold)),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 14),
+              TextField(
+                controller: qtyCtrl,
+                keyboardType: TextInputType.number,
+                decoration: InputDecoration(
+                    labelText: 'Quantidade (${item.unit})',
+                    prefixIcon: Icon(
+                        isEntry ? Icons.add_circle : Icons.remove_circle,
+                        color: isEntry
+                            ? AppColors.neonGreen
+                            : AppColors.neonRed)),
+              ),
+              const SizedBox(height: 10),
+              TextField(
+                controller: reasonCtrl,
+                decoration: const InputDecoration(
+                    labelText: 'Motivo (ex: Produção, Devolução)'),
+              ),
+              const SizedBox(height: 20),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor:
+                        isEntry ? AppColors.neonGreen : AppColors.neonRed,
+                    foregroundColor: AppColors.bgDeep,
+                  ),
+                  onPressed: () {
+                    final qty = double.tryParse(qtyCtrl.text);
+                    if (qty == null || qty <= 0) return;
+                    final delta = isEntry ? qty : -qty;
+                    op.updateBalance(item.code, delta,
+                        reasonCtrl.text.isEmpty ? (isEntry ? 'Entrada' : 'Saída') : reasonCtrl.text);
+                    HapticFeedback.lightImpact();
+                    Navigator.pop(ctx);
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text(
+                            '${isEntry ? '+' : '-'}${qty.toInt()} ${item.unit} em ${item.description}'),
+                        backgroundColor: isEntry
+                            ? AppColors.neonGreen
+                            : AppColors.neonRed,
+                      ),
+                    );
+                  },
+                  child: Text(
+                      isEntry ? 'Confirmar Entrada' : 'Confirmar Saída',
+                      style:
+                          const TextStyle(fontWeight: FontWeight.bold)),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  // ─── Build ─────────────────────────────────────────────────────────────────
+
   @override
   Widget build(BuildContext context) {
-    final operationalProvider = Provider.of<OperationalProvider>(context);
-    final items = operationalProvider.items;
+    final op = Provider.of<OperationalProvider>(context);
 
     return Scaffold(
       backgroundColor: Colors.transparent,
       floatingActionButton: FloatingActionButton(
-        onPressed: _showAddProductDialog,
-        backgroundColor: Theme.of(context).colorScheme.secondary,
-        child: const Icon(Icons.add, color: Colors.white),
+        onPressed: _showAddDialog,
+        backgroundColor: AppColors.neonCyan,
+        child: const Icon(Icons.add, color: AppColors.bgDeep),
       ),
       body: Column(
         children: [
+          // ─ Barra de busca + scanner + filtro
           Padding(
-            padding: const EdgeInsets.all(16.0),
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
             child: Row(
               children: [
                 Expanded(
                   child: TextField(
+                    controller: _searchCtrl,
+                    onChanged: (v) {
+                      op.setSearch(v);
+                    },
                     decoration: InputDecoration(
-                      hintText: 'Buscar por código, Corredor...',
-                      prefixIcon: const Icon(Icons.search),
+                      hintText: 'Buscar código, nome, corredor…',
+                      prefixIcon:
+                          const Icon(Icons.search, color: AppColors.textLow),
+                      suffixIcon: _searchCtrl.text.isNotEmpty
+                          ? IconButton(
+                              icon: const Icon(Icons.close,
+                                  color: AppColors.textLow, size: 18),
+                              onPressed: () {
+                                _searchCtrl.clear();
+                                op.setSearch('');
+                              },
+                            )
+                          : null,
                       filled: true,
                       fillColor: Theme.of(context).colorScheme.surface,
                       border: OutlineInputBorder(
@@ -103,169 +467,356 @@ class _OperationalScreenState extends State<OperationalScreen> {
                   ),
                 ),
                 const SizedBox(width: 8),
+                // Botão scanner
                 IconButton(
                   style: IconButton.styleFrom(
-                    backgroundColor: Theme.of(context).colorScheme.surface,
+                      backgroundColor: AppColors.neonCyan.withValues(alpha: 0.12),
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12))),
+                  icon: const Icon(Icons.qr_code_scanner,
+                      color: AppColors.neonCyan),
+                  onPressed: _openScanner,
+                  tooltip: 'Escanear código',
+                ),
+                const SizedBox(width: 4),
+                // Botão filtro
+                IconButton(
+                  style: IconButton.styleFrom(
+                    backgroundColor: _filterOpen
+                        ? AppColors.neonPurple.withValues(alpha: 0.2)
+                        : Theme.of(context).colorScheme.surface,
+                    shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12)),
                   ),
-                  icon: const Icon(Icons.filter_list),
-                  onPressed: () {},
-                )
+                  icon: Icon(Icons.filter_list,
+                      color: _filterOpen
+                          ? AppColors.neonPurple
+                          : AppColors.textLow),
+                  onPressed: () =>
+                      setState(() => _filterOpen = !_filterOpen),
+                ),
               ],
             ),
           ),
+
+          // ─ Chips de categoria (expansível)
+          AnimatedSize(
+            duration: const Duration(milliseconds: 250),
+            child: _filterOpen
+                ? SizedBox(
+                    height: 48,
+                    child: ListView.separated(
+                      scrollDirection: Axis.horizontal,
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 16, vertical: 6),
+                      itemCount: _categories.length,
+                      separatorBuilder: (_, __) =>
+                          const SizedBox(width: 8),
+                      itemBuilder: (_, i) {
+                        final cat = _categories[i];
+                        final active = cat == _selectedCategory;
+                        return ChoiceChip(
+                          label: Text(cat),
+                          selected: active,
+                          onSelected: (_) {
+                            setState(
+                                () => _selectedCategory = cat);
+                            op.setCategoryFilter(
+                                cat == 'Todos' ? null : cat);
+                          },
+                          selectedColor:
+                              AppColors.neonPurple.withValues(alpha: 0.2),
+                          labelStyle: TextStyle(
+                              color: active
+                                  ? AppColors.neonPurple
+                                  : AppColors.textLow,
+                              fontWeight: active
+                                  ? FontWeight.bold
+                                  : FontWeight.normal),
+                          side: BorderSide(
+                              color: active
+                                  ? AppColors.neonPurple
+                                      .withValues(alpha: 0.6)
+                                  : AppColors.border),
+                          backgroundColor: AppColors.bgSurface,
+                        );
+                      },
+                    ),
+                  )
+                : const SizedBox.shrink(),
+          ),
+
+          // ─ KPI rápido
+          if (!op.isLoading)
+            Padding(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Row(
+                children: [
+                  _kpiChip(
+                      '${op.totalItems} itens',
+                      Icons.inventory_2_outlined,
+                      AppColors.neonCyan),
+                  const SizedBox(width: 8),
+                  _kpiChip(
+                      '${op.lowStockItems.length} reposicões',
+                      Icons.warning_amber,
+                      op.lowStockItems.isEmpty
+                          ? AppColors.neonGreen
+                          : AppColors.neonRed),
+                  const SizedBox(width: 8),
+                  _kpiChip(
+                      'R\$ ${(op.totalStockValue / 1000).toStringAsFixed(1)}K',
+                      Icons.attach_money,
+                      AppColors.neonAmber),
+                ],
+              ),
+            ),
+
+          // ─ Loading
+          if (op.isLoading)
+            const Expanded(
+              child: Center(
+                child: CircularProgressIndicator(color: AppColors.neonCyan),
+              ),
+            )
+          else
+
+          // ─ Lista
           Expanded(
             child: RefreshIndicator(
-              onRefresh: () async {
-                final scaffoldMessenger = ScaffoldMessenger.of(context);
-                await Future.delayed(const Duration(seconds: 1));
-                if (mounted) {
-                  scaffoldMessenger.showSnackBar(
-                    const SnackBar(content: Text('Estoque Atualizado!')),
-                  );
-                }
-              },
-              child: ListView.builder(
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                itemCount: items.length,
-                itemBuilder: (context, index) {
-                final item = items[index];
-                final lowStock = item.isLowStock;
-
-                return Dismissible(
-                  key: Key(item.code),
-                  direction: DismissDirection.endToStart,
-                  background: Container(
-                    alignment: Alignment.centerRight,
-                    padding: const EdgeInsets.symmetric(horizontal: 20),
-                    decoration: BoxDecoration(
-                      color: Colors.redAccent,
-                      borderRadius: BorderRadius.circular(16),
+              color: AppColors.neonCyan,
+              onRefresh: () => op.loadFromApi(),
+              child: op.items.isEmpty
+                  ? _emptyState()
+                  : ListView.builder(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 16, vertical: 4),
+                      itemCount: op.items.length,
+                      itemBuilder: (ctx, i) =>
+                          _itemCard(ctx, op.items[i], op),
                     ),
-                    child: const Icon(Icons.delete, color: Colors.white),
-                  ),
-                  confirmDismiss: (direction) async {
-                    return await showDialog(
-                      context: context,
-                      builder: (context) => AlertDialog(
-                        title: const Text('Confirmar Exclusão'),
-                        content: Text('Deseja remover "${item.description}" do estoque?'),
-                        actions: [
-                          TextButton(
-                            onPressed: () => Navigator.pop(context, false),
-                            child: const Text('Cancelar'),
-                          ),
-                          ElevatedButton(
-                            style: ElevatedButton.styleFrom(backgroundColor: Colors.redAccent),
-                            onPressed: () => Navigator.pop(context, true),
-                            child: const Text('Excluir'),
-                          ),
-                        ],
-                      ),
-                    );
-                  },
-                  onDismissed: (direction) {
-                    operationalProvider.removeItem(item.code);
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text('${item.description} removido.')),
-                    );
-                  },
-                  child: Card(
-                    margin: const EdgeInsets.only(bottom: 12),
-                    shape: Border(
-                      left: BorderSide(
-                        color: lowStock ? Colors.redAccent : Theme.of(context).primaryColor,
-                        width: 4,
-                      ),
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.all(16.0),
-                      child: Row(
-                        children: [
-                          Container(
-                            width: 50,
-                            height: 50,
-                            decoration: BoxDecoration(
-                              color: Colors.white.withValues(alpha: 0.05),
-                              borderRadius: BorderRadius.circular(10),
-                            ),
-                            child: Icon(
-                              _getIconForCategory(item.category),
-                              color: Theme.of(context).colorScheme.secondary,
-                            ),
-                          ),
-                          const SizedBox(width: 16),
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  item.description,
-                                  style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
-                                ),
-                                const SizedBox(height: 4),
-                                Text(
-                                  '${item.code} • ${item.category}',
-                                  style: TextStyle(color: Colors.white.withValues(alpha: 0.6), fontSize: 12),
-                                ),
-                                const SizedBox(height: 8),
-                                Row(
-                                  children: [
-                                    const Icon(Icons.location_on, size: 14, color: Colors.grey),
-                                    const SizedBox(width: 4),
-                                    Text(
-                                      item.location,
-                                      style: const TextStyle(fontSize: 12, color: Colors.grey),
-                                    ),
-                                  ],
-                                ),
-                              ],
-                            ),
-                          ),
-                          Column(
-                            crossAxisAlignment: CrossAxisAlignment.end,
-                            children: [
-                              Text(
-                                item.balance,
-                                style: TextStyle(
-                                  fontSize: 18,
-                                  fontWeight: FontWeight.bold,
-                                  color: lowStock ? Colors.redAccent : Colors.white,
-                                ),
-                              ),
-                              if (lowStock)
-                                Container(
-                                  margin: const EdgeInsets.only(top: 8),
-                                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                                  decoration: BoxDecoration(
-                                    color: Colors.redAccent.withValues(alpha: 0.2),
-                                    borderRadius: BorderRadius.circular(10),
-                                  ),
-                                  child: const Text(
-                                    'Repor Urgent.',
-                                    style: TextStyle(color: Colors.redAccent, fontSize: 10, fontWeight: FontWeight.bold),
-                                  ),
-                                ),
-                            ],
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                );
-              },
             ),
           ),
-        ),
-      ],
+        ],
       ),
     );
   }
 
-  IconData _getIconForCategory(String category) {
-    if (category == 'Tecidos') return Icons.layers;
-    if (category == 'Espumas') return Icons.cloud;
-    if (category == 'Ferragens') return Icons.build;
-    if (category == 'Ferramentas') return Icons.handyman;
-    return Icons.weekend;
+  // ─── Widgets auxiliares ─────────────────────────────────────────────────────
+
+  Widget _kpiChip(String label, IconData icon, Color color) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, color: color, size: 13),
+          const SizedBox(width: 5),
+          Text(label,
+              style: TextStyle(
+                  color: color,
+                  fontSize: 11,
+                  fontWeight: FontWeight.bold)),
+        ],
+      ),
+    );
+  }
+
+  Widget _emptyState() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.inventory_2_outlined,
+              size: 64,
+              color: AppColors.textLow.withValues(alpha: 0.4)),
+          const SizedBox(height: 16),
+          const Text('Nenhum item encontrado',
+              style:
+                  TextStyle(color: AppColors.textLow, fontSize: 15)),
+          const SizedBox(height: 8),
+          const Text('Ajuste a busca ou adicione um novo item',
+              style:
+                  TextStyle(color: AppColors.textLow, fontSize: 12)),
+        ],
+      ),
+    );
+  }
+
+  Widget _itemCard(
+      BuildContext ctx, InventoryItem item, OperationalProvider op) {
+    final lowStock = item.isLowStock;
+    final statusColor =
+        lowStock ? AppColors.neonRed : AppColors.neonGreen;
+
+    return Dismissible(
+      key: Key(item.code),
+      direction: DismissDirection.endToStart,
+      background: Container(
+        alignment: Alignment.centerRight,
+        margin: const EdgeInsets.only(bottom: 12),
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        decoration: BoxDecoration(
+          color: Colors.redAccent,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: const Icon(Icons.delete, color: Colors.white),
+      ),
+      confirmDismiss: (_) async => await showDialog<bool>(
+        context: ctx,
+        builder: (_) => AlertDialog(
+          title: const Text('Confirmar Exclusão'),
+          content:
+              Text('Remover "${item.description}" do estoque?'),
+          actions: [
+            TextButton(
+                onPressed: () => Navigator.pop(ctx, false),
+                child: const Text('Cancelar')),
+            ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.redAccent),
+                onPressed: () => Navigator.pop(ctx, true),
+                child: const Text('Excluir')),
+          ],
+        ),
+      ),
+      onDismissed: (_) {
+        op.removeItem(item.code);
+        ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('${item.description} removido.')));
+      },
+      child: GestureDetector(
+        onTap: () => _showMovementSheet(item),
+        child: Container(
+          margin: const EdgeInsets.only(bottom: 12),
+          decoration: BoxDecoration(
+            color: AppColors.bgCard,
+            borderRadius: BorderRadius.circular(16),
+            border: Border(
+              left: BorderSide(color: statusColor, width: 4),
+              top: BorderSide(
+                  color: AppColors.border.withValues(alpha: 0.5)),
+              right: BorderSide(
+                  color: AppColors.border.withValues(alpha: 0.5)),
+              bottom: BorderSide(
+                  color: AppColors.border.withValues(alpha: 0.5)),
+            ),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(14),
+            child: Row(
+              children: [
+                // Ícone categoria
+                Container(
+                  width: 46,
+                  height: 46,
+                  decoration: BoxDecoration(
+                    color: statusColor.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Icon(_iconForCategory(item.category),
+                      color: statusColor, size: 22),
+                ),
+                const SizedBox(width: 14),
+                // Info
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(item.description,
+                          style: const TextStyle(
+                              fontWeight: FontWeight.bold,
+                              fontSize: 15,
+                              color: AppColors.textHigh)),
+                      const SizedBox(height: 3),
+                      Text(
+                          '${item.code} • ${item.category}',
+                          style: const TextStyle(
+                              color: AppColors.textLow,
+                              fontSize: 11)),
+                      const SizedBox(height: 5),
+                      Row(
+                        children: [
+                          const Icon(Icons.location_on,
+                              size: 12,
+                              color: AppColors.textLow),
+                          const SizedBox(width: 3),
+                          Text(item.location,
+                              style: const TextStyle(
+                                  fontSize: 11,
+                                  color: AppColors.textLow)),
+                          if (item.supplier != null) ...[
+                            const SizedBox(width: 8),
+                            const Icon(Icons.local_shipping,
+                                size: 12,
+                                color: AppColors.textLow),
+                            const SizedBox(width: 3),
+                            Text(item.supplier!,
+                                style: const TextStyle(
+                                    fontSize: 11,
+                                    color: AppColors.textLow)),
+                          ]
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                // Saldo + badge
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Text(item.balanceLabel,
+                        style: TextStyle(
+                            fontSize: 17,
+                            fontWeight: FontWeight.bold,
+                            color: statusColor)),
+                    const SizedBox(height: 4),
+                    if (item.cost > 0)
+                      Text(
+                          'R\$ ${item.totalValue.toStringAsFixed(0)}',
+                          style: const TextStyle(
+                              fontSize: 10,
+                              color: AppColors.textLow)),
+                    if (lowStock)
+                      Container(
+                        margin: const EdgeInsets.only(top: 5),
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 8, vertical: 3),
+                        decoration: BoxDecoration(
+                          color: AppColors.neonRed
+                              .withValues(alpha: 0.15),
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                        child: const Text('Repor',
+                            style: TextStyle(
+                                color: AppColors.neonRed,
+                                fontSize: 9,
+                                fontWeight: FontWeight.bold)),
+                      ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  IconData _iconForCategory(String cat) {
+    switch (cat) {
+      case 'Tecidos': return Icons.layers;
+      case 'Espumas': return Icons.cloud;
+      case 'Ferragens': return Icons.build;
+      case 'Ferramentas': return Icons.handyman;
+      case 'Madeiras': return Icons.forest;
+      default: return Icons.weekend;
+    }
   }
 }


### PR DESCRIPTION
## PR #C — OperationalScreen + FinancialScreen

> **Requer PR #A merged** (depende de `InventoryItem.qty`, `OperationalProvider.updateBalance()`, `ApiService`, `AppColors`)

---

## Arquivos alterados (2)

---

### `presentation/screens/operational_screen.dart` — REFATORADO COMPLETO

#### Problemas corrigidos
| Antes | Depois |
|---|---|
| `InventoryItem(balance: "0 UN")` | `InventoryItem(qty: 0, unit: 'UN')` tipado correto |
| Busca no TextField sem efeito | `op.setSearch()` conectado ao `onChanged` |
| Filtro (botão `filter_list`) sem ação | Chips de categoria expansíveis com `op.setCategoryFilter()` |
| `onRefresh` com `Future.delayed` fake | `op.loadFromApi()` real |
| Sem carregamento inicial | `loadFromApi()` no `initState` |
| Sem scanner no formulário | Botão QR no campo Código SKU |
| Dialog de cadastro sem validação | `Form` com `GlobalKey` + `TextFormField` com `validator` |
| Sem campo custo / estoque mínimo | `cost`, `minimumStock`, `unit`, `supplier` no form |
| Tap no card sem ação | `GestureDetector` → `_showMovementSheet()` |
| Sem movimentação de estoque | Bottom sheet com toggle **Entrada / Saída** + `op.updateBalance()` |
| `item.balance` (String) exibido | `item.balanceLabel` + `item.totalValue` com custo |
| Sem KPIs | Row com chips: total itens, reposições pendentes, capital em estoque |
| Sem empty state | Widget com ícone e texto ao filtrar sem resultados |

#### Novas features
- **Bottom sheet de movimentação** — toggle Entrada/Saída com cor reativa (green/red), campo motivo, `updateBalance()` real
- **Scanner no formulário** — botão QR no SKU abre `BarcodeScannerScreen` e preenche o campo
- **KPI row** — 3 chips: itens totais, reposições urgentes, capital total em estoque (R$)
- **Chips de categoria** — expansível com `AnimatedSize`, integrado ao `setCategoryFilter()`
- **Loading state** — `CircularProgressIndicator` enquanto `op.isLoading`
- **Fornecedor** exibido no card quando preenchido

---

### `presentation/screens/financial_screen.dart` — REFATORADO COMPLETO

#### Problemas corrigidos
| Antes | Depois |
|---|---|
| `StatelessWidget` com dados hardcoded | `StatefulWidget` com `_loadData()` assíncrono |
| Sem chamada HTTP | `ApiService.getFinancialSummary()` + `getTransactions()` |
| Sem gráfico | `LineChart` com fl_chart (receitas vs despesas, 6 meses) |
| ROI hardcoded | Lido de `_summary['roi']` da API |
| Sem loading state | `CircularProgressIndicator` durante `_loadData` |
| Sem seletor de período | Chips `7D / 30D / 3M` que relançam `_loadData()` |
| Botão WhatsApp sem destino | `Navigator.push → WhatsAppReportScreen` |
| Capital de estoque ausente | `op.totalStockValue` integrado como sub-KPI |

#### Novas features
- **`fl_chart` LineChart** — curvas suaves, área preenchida para receitas, linha tracejada para despesas
- **Legenda visual** — linha colorida com label (Receitas / Despesas)
- **Selector 7D / 30D / 3M** — troca período e relança fetch
- **Timeline de transações** — linha do tempo com círculo colorido, badge de categoria e status
- **Pull-to-refresh** — `RefreshIndicator` relança `_loadData()`
- **Fallback offline** completo com dados mock realistas da S.F.C.P.C

---

## Dependências necessárias no `pubspec.yaml`

Verifique se `fl_chart` já está no projeto:
```yaml
dependencies:
  fl_chart: ^0.68.0  # adicionar se não existir
```

## Próximo passo após merge
→ **PR #D** — SettingsScreen + HomeScreen Dashboard + correções finais