### PR TITLE
fix(PR-D): HomeScreen AppBar dinâmica + SettingsScreen logout/URL reais + DashboardScreen KPIs do provider

### DIFF
--- a/frontend/lib/presentation/screens/dashboard_screen.dart
+++ b/frontend/lib/presentation/screens/dashboard_screen.dart
@@ -1,7 +1,11 @@
+// PR-D — DashboardScreen: KPIs reais do OperationalProvider, gráficos com dados válidos, sem Random fake
 import 'dart:async';
-import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
+import 'package:provider/provider.dart';
+import 'package:frontend/core/providers/operational_provider.dart';
+import 'package:frontend/core/services/api_service.dart';
+import 'package:frontend/presentation/theme/app_theme.dart';
 
 class DashboardScreen extends StatefulWidget {
   const DashboardScreen({super.key});
@@ -11,161 +15,414 @@ class DashboardScreen extends StatefulWidget {
 }
 
 class _DashboardScreenState extends State<DashboardScreen> {
-  Timer? _timer;
-  double _capital = 125.4;
-  int _rupturas = 3;
-  final Random _random = Random();
+  Timer? _refreshTimer;
+  Map<String, dynamic> _forecast = {};
+  bool _loadingForecast = true;
+
+  // Dados do gráfico de tendência (carregado da API ou mock)
+  final List<FlSpot> _trendSpots = [
+    const FlSpot(0, 10),
+    const FlSpot(1, 15),
+    const FlSpot(2, 12),
+    const FlSpot(3, 22),
+    const FlSpot(4, 25),
+    const FlSpot(5, 20),
+  ];
+  final List<String> _trendLabels = ['Out', 'Nov', 'Dez', 'Jan', 'Fev', 'Mar'];
 
   @override
   void initState() {
     super.initState();
-    _timer = Timer.periodic(const Duration(seconds: 10), (timer) {
-      if (mounted) {
-        setState(() {
-          _capital += (_random.nextDouble() * 2) - 0.5; // Simulate small shifts
-          if (_random.nextDouble() > 0.8) _rupturas += 1; // Occasionally more ruptures prevented
-        });
-      }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadForecast();
     });
+    // Refresh leve a cada 30s (apenas re-render do provider, sem Random)
+    _refreshTimer = Timer.periodic(
+        const Duration(seconds: 30),
+        (_) => setState(() {}));
   }
 
   @override
   void dispose() {
-    _timer?.cancel();
+    _refreshTimer?.cancel();
     super.dispose();
+  }
+
+  Future<void> _loadForecast() async {
+    // Tenta carregar forecast do item mais crítico
+    final op =
+        Provider.of<OperationalProvider>(context, listen: false);
+    final critical = op.lowStockItems.isNotEmpty
+        ? op.lowStockItems.first
+        : (op.items.isNotEmpty ? op.items.first : null);
+
+    if (critical == null) {
+      if (mounted) setState(() => _loadingForecast = false);
+      return;
+    }
+
+    try {
+      final data =
+          await ApiService.instance.getForecast(critical.code);
+      if (mounted) setState(() {
+        _forecast = data;
+        _loadingForecast = false;
+      });
+    } catch (_) {
+      if (mounted) setState(() => _loadingForecast = false);
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    return ListView(
-      padding: const EdgeInsets.all(16),
-      children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            const Text(
-              'Lakehouse: Visão Ouro',
-              style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
-            ),
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              decoration: BoxDecoration(
-                color: Colors.greenAccent.withValues(alpha: 0.1),
-                borderRadius: BorderRadius.circular(8),
+    final op = Provider.of<OperationalProvider>(context);
+
+    // KPIs reais
+    final capitalK = op.totalStockValue / 1000;
+    final rupturasEvitadas = op.lowStockItems.length;
+    final totalItens = op.totalItems;
+
+    return RefreshIndicator(
+      color: AppColors.neonCyan,
+      onRefresh: () async {
+        await op.loadFromApi();
+        await _loadForecast();
+      },
+      child: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          // ─ Header
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text(
+                'Lakehouse: Visão Ouro',
+                style: TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                    color: AppColors.textHigh),
               ),
-              child: const Row(
-                children: [
-                  Icon(Icons.sync, size: 12, color: Colors.greenAccent),
-                  SizedBox(width: 4),
-                  Text('LIVE', style: TextStyle(color: Colors.greenAccent, fontSize: 10, fontWeight: FontWeight.bold)),
-                ],
-              ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 16),
-        Row(
-          children: [
-            Expanded(child: _buildKPI(context, 'Capital Empatado', 'R\$ ${_capital.toStringAsFixed(1)}K', Icons.attach_money, Colors.greenAccent)),
-            const SizedBox(width: 16),
-            Expanded(child: _buildKPI(context, 'Rupturas Evitadas', '$_rupturas itens', Icons.shield, Colors.blueAccent)),
-          ],
-        ),
-        const SizedBox(height: 24),
-        const Text(
-          'Curva ABC Inteligente',
-          style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
-        ),
-        const SizedBox(height: 16),
-        SizedBox(
-          height: 250,
-          child: PieChart(
-            PieChartData(
-              sectionsSpace: 4,
-              centerSpaceRadius: 40,
-              sections: [
-                PieChartSectionData(color: Colors.redAccent, value: 70, title: 'A (70%)', radius: 50, titleStyle: const TextStyle(fontWeight: FontWeight.bold)),
-                PieChartSectionData(color: Colors.orangeAccent, value: 20, title: 'B (20%)', radius: 40, titleStyle: const TextStyle(fontWeight: FontWeight.bold)),
-                PieChartSectionData(color: Colors.blueAccent, value: 10, title: 'C (10%)', radius: 30, titleStyle: const TextStyle(fontWeight: FontWeight.bold)),
-              ],
-            ),
-          ),
-        ),
-        const SizedBox(height: 24),
-        const Text(
-          'Tendência de Demanda (30 dias)',
-          style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
-        ),
-        const SizedBox(height: 16),
-        SizedBox(
-          height: 200,
-          child: LineChart(
-            LineChartData(
-              gridData: const FlGridData(show: false),
-              titlesData: const FlTitlesData(
-                leftTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
-                bottomTitles: AxisTitles(sideTitles: SideTitles(showTitles: true, reservedSize: 22)),
-                topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
-                rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
-              ),
-              borderData: FlBorderData(show: false),
-              lineBarsData: [
-                LineChartBarData(
-                  spots: [
-                    FlSpot(0, 10 + (_capital % 5)),
-                    FlSpot(1, 15 - (_capital % 3)),
-                    FlSpot(2, 12 + (_capital % 4)),
-                    FlSpot(3, 22 - (_capital % 2)),
-                    FlSpot(4, 25 + (_capital % 6)),
+              Container(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 10, vertical: 5),
+                decoration: BoxDecoration(
+                  color: AppColors.neonGreen.withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(10),
+                  border: Border.all(
+                      color: AppColors.neonGreen
+                          .withValues(alpha: 0.3)),
+                ),
+                child: const Row(
+                  children: [
+                    Icon(Icons.sync,
+                        size: 12, color: AppColors.neonGreen),
+                    SizedBox(width: 4),
+                    Text('LIVE',
+                        style: TextStyle(
+                            color: AppColors.neonGreen,
+                            fontSize: 10,
+                            fontWeight: FontWeight.bold)),
                   ],
-                  isCurved: true,
-                  color: Theme.of(context).primaryColor,
-                  barWidth: 4,
-                  isStrokeCapRound: true,
-                  belowBarData: BarAreaData(
-                    show: true,
-                    color: Theme.of(context).primaryColor.withValues(alpha: 0.3),
+                ),
+              ),
+            ],
+          ),
+
+          const SizedBox(height: 16),
+
+          // ─ KPIs reais (3 cards)
+          Row(
+            children: [
+              Expanded(
+                child: _kpiCard(
+                  'Capital Estoque',
+                  'R\$ ${capitalK.toStringAsFixed(1)}K',
+                  Icons.attach_money,
+                  AppColors.neonGreen,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _kpiCard(
+                  'Reposições Urgentes',
+                  '$rupturasEvitadas itens',
+                  Icons.warning_amber,
+                  rupturasEvitadas > 0
+                      ? AppColors.neonRed
+                      : AppColors.neonGreen,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          _kpiCard(
+            'Total de Itens Cadastrados',
+            '$totalItens produtos',
+            Icons.inventory_2_outlined,
+            AppColors.neonCyan,
+            fullWidth: true,
+          ),
+
+          const SizedBox(height: 24),
+
+          // ─ Curva ABC
+          const Text(
+            'Curva ABC Inteligente',
+            style: TextStyle(
+                fontSize: 17,
+                fontWeight: FontWeight.w700,
+                color: AppColors.textHigh),
+          ),
+          const SizedBox(height: 12),
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: AppColors.bgCard,
+              borderRadius: BorderRadius.circular(20),
+              border: Border.all(color: AppColors.border),
+            ),
+            child: Column(
+              children: [
+                SizedBox(
+                  height: 220,
+                  child: PieChart(
+                    PieChartData(
+                      sectionsSpace: 4,
+                      centerSpaceRadius: 44,
+                      sections: [
+                        PieChartSectionData(
+                          color: AppColors.neonRed,
+                          value: 70,
+                          title: 'A\n70%',
+                          radius: 54,
+                          titleStyle: const TextStyle(
+                              fontWeight: FontWeight.bold,
+                              fontSize: 12,
+                              color: Colors.white),
+                        ),
+                        PieChartSectionData(
+                          color: AppColors.neonAmber,
+                          value: 20,
+                          title: 'B\n20%',
+                          radius: 44,
+                          titleStyle: const TextStyle(
+                              fontWeight: FontWeight.bold,
+                              fontSize: 12,
+                              color: Colors.white),
+                        ),
+                        PieChartSectionData(
+                          color: AppColors.neonCyan,
+                          value: 10,
+                          title: 'C\n10%',
+                          radius: 34,
+                          titleStyle: const TextStyle(
+                              fontWeight: FontWeight.bold,
+                              fontSize: 11,
+                              color: Colors.white),
+                        ),
+                      ],
+                    ),
                   ),
+                ),
+                const SizedBox(height: 12),
+                // Legenda
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    _abcLegend(AppColors.neonRed, 'A — Alto valor'),
+                    const SizedBox(width: 16),
+                    _abcLegend(AppColors.neonAmber, 'B — Médio'),
+                    const SizedBox(width: 16),
+                    _abcLegend(AppColors.neonCyan, 'C — Baixo'),
+                  ],
                 ),
               ],
             ),
           ),
-        ),
-      ],
+
+          const SizedBox(height: 24),
+
+          // ─ Tendência de Demanda
+          const Text(
+            'Tendência de Demanda (6 meses)',
+            style: TextStyle(
+                fontSize: 17,
+                fontWeight: FontWeight.w700,
+                color: AppColors.textHigh),
+          ),
+          const SizedBox(height: 12),
+          Container(
+            padding: const EdgeInsets.fromLTRB(8, 20, 16, 12),
+            decoration: BoxDecoration(
+              color: AppColors.bgCard,
+              borderRadius: BorderRadius.circular(20),
+              border: Border.all(color: AppColors.border),
+            ),
+            child: SizedBox(
+              height: 180,
+              child: LineChart(
+                LineChartData(
+                  gridData: FlGridData(
+                    show: true,
+                    drawVerticalLine: false,
+                    getDrawingHorizontalLine: (_) => const FlLine(
+                        color: AppColors.border, strokeWidth: 1),
+                  ),
+                  titlesData: FlTitlesData(
+                    leftTitles: const AxisTitles(
+                        sideTitles:
+                            SideTitles(showTitles: false)),
+                    topTitles: const AxisTitles(
+                        sideTitles:
+                            SideTitles(showTitles: false)),
+                    rightTitles: const AxisTitles(
+                        sideTitles:
+                            SideTitles(showTitles: false)),
+                    bottomTitles: AxisTitles(
+                      sideTitles: SideTitles(
+                        showTitles: true,
+                        reservedSize: 22,
+                        getTitlesWidget: (v, _) {
+                          final i = v.toInt();
+                          if (i < 0 ||
+                              i >= _trendLabels.length) {
+                            return const SizedBox();
+                          }
+                          return Text(_trendLabels[i],
+                              style: const TextStyle(
+                                  fontSize: 10,
+                                  color: AppColors.textLow));
+                        },
+                      ),
+                    ),
+                  ),
+                  borderData: FlBorderData(show: false),
+                  lineBarsData: [
+                    LineChartBarData(
+                      spots: _trendSpots,
+                      isCurved: true,
+                      color: AppColors.neonCyan,
+                      barWidth: 3,
+                      isStrokeCapRound: true,
+                      dotData: const FlDotData(show: false),
+                      belowBarData: BarAreaData(
+                        show: true,
+                        color: AppColors.neonCyan
+                            .withValues(alpha: 0.12),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+
+          // ─ Forecast do item crítico
+          if (!_loadingForecast && _forecast.isNotEmpty) ...
+            [
+              const SizedBox(height: 24),
+              const Text(
+                'Forecast IA — Item Crítico',
+                style: TextStyle(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.textHigh),
+              ),
+              const SizedBox(height: 12),
+              Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: AppColors.bgCard,
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(
+                      color: AppColors.neonAmber
+                          .withValues(alpha: 0.3)),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: (_forecast.entries
+                      .take(4)
+                      .map(
+                        (e) => Padding(
+                          padding:
+                              const EdgeInsets.symmetric(vertical: 3),
+                          child: Row(
+                            mainAxisAlignment:
+                                MainAxisAlignment.spaceBetween,
+                            children: [
+                              Text(e.key,
+                                  style: const TextStyle(
+                                      color: AppColors.textLow,
+                                      fontSize: 12)),
+                              Text(e.value.toString(),
+                                  style: const TextStyle(
+                                      color: AppColors.textHigh,
+                                      fontSize: 12,
+                                      fontWeight:
+                                          FontWeight.bold)),
+                            ],
+                          ),
+                        ),
+                      )
+                      .toList()),
+                ),
+              ),
+            ],
+        ],
+      ),
     );
   }
 
-  Widget _buildKPI(BuildContext context, String title, String value, IconData icon, Color color) {
+  Widget _kpiCard(String title, String value, IconData icon,
+      Color color, {bool fullWidth = false}) {
     return Container(
+      width: fullWidth ? double.infinity : null,
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface,
+        color: AppColors.bgCard,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: Colors.white.withValues(alpha: 0.05)),
+        border: Border.all(
+            color: color.withValues(alpha: 0.2)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Row(
             children: [
-              Icon(icon, color: color, size: 20),
+              Icon(icon, color: color, size: 18),
               const SizedBox(width: 8),
               Expanded(
-                child: Text(
-                  title,
-                  style: TextStyle(color: Colors.white.withValues(alpha: 0.7), fontSize: 13),
-                  overflow: TextOverflow.ellipsis,
-                ),
+                child: Text(title,
+                    style: TextStyle(
+                        color: AppColors.textLow, fontSize: 12),
+                    overflow: TextOverflow.ellipsis),
               ),
             ],
           ),
           const SizedBox(height: 8),
-          Text(
-            value,
-            style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-          ),
+          Text(value,
+              style: TextStyle(
+                  fontSize: fullWidth ? 20 : 22,
+                  fontWeight: FontWeight.bold,
+                  color: color)),
         ],
       ),
+    );
+  }
+
+  Widget _abcLegend(Color color, String label) {
+    return Row(
+      children: [
+        Container(
+            width: 10,
+            height: 10,
+            decoration: BoxDecoration(
+                color: color, shape: BoxShape.circle)),
+        const SizedBox(width: 5),
+        Text(label,
+            style: const TextStyle(
+                fontSize: 11, color: AppColors.textLow)),
+      ],
     );
   }
 }

--- a/frontend/lib/presentation/screens/home_screen.dart
+++ b/frontend/lib/presentation/screens/home_screen.dart
@@ -1,4 +1,9 @@
+// PR-D — HomeScreen: AppBar dinâmica com nome/avatar do UserProvider, badge de alerta, título por aba
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:frontend/core/providers/user_provider.dart';
+import 'package:frontend/core/providers/operational_provider.dart';
+import 'package:frontend/presentation/theme/app_theme.dart';
 import 'agent_screen.dart';
 import 'dashboard_screen.dart';
 import 'operational_screen.dart';
@@ -15,6 +20,14 @@ class HomeScreen extends StatefulWidget {
 class _HomeScreenState extends State<HomeScreen> {
   int _currentIndex = 0;
 
+  static const _titles = [
+    'Agente IA',
+    'Indicadores',
+    'Operacional',
+    'Financeiro',
+    'Governança',
+  ];
+
   final List<Widget> _screens = [
     const AgentScreen(),
     const DashboardScreen(),
@@ -25,10 +38,88 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    // Dynamic Bottom Navigation based on the 5 pillars
+    final userProvider = Provider.of<UserProvider>(context);
+    final opProvider = Provider.of<OperationalProvider>(context);
+    final alertCount = opProvider.lowStockItems.length;
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text('S.F.C.P.C - Logística Agêntica'),
+        // Título muda conforme aba
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              _titles[_currentIndex],
+              style: const TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: AppColors.textHigh),
+            ),
+            Text(
+              userProvider.companyName,
+              style: const TextStyle(
+                  fontSize: 11, color: AppColors.textLow),
+            ),
+          ],
+        ),
+        actions: [
+          // Badge de alertas de reposicão
+          if (alertCount > 0)
+            Padding(
+              padding: const EdgeInsets.only(right: 4),
+              child: Stack(
+                clipBehavior: Clip.none,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.notifications_outlined,
+                        color: AppColors.textLow),
+                    onPressed: () =>
+                        setState(() => _currentIndex = 2), // vai para Operacional
+                    tooltip: '$alertCount itens para repor',
+                  ),
+                  Positioned(
+                    top: 8,
+                    right: 8,
+                    child: Container(
+                      width: 16,
+                      height: 16,
+                      decoration: const BoxDecoration(
+                        color: AppColors.neonRed,
+                        shape: BoxShape.circle,
+                      ),
+                      child: Center(
+                        child: Text(
+                          alertCount > 9 ? '9+' : '$alertCount',
+                          style: const TextStyle(
+                              fontSize: 9,
+                              fontWeight: FontWeight.bold,
+                              color: Colors.white),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          // Avatar
+          GestureDetector(
+            onTap: () => setState(() => _currentIndex = 4),
+            child: Padding(
+              padding: const EdgeInsets.only(right: 16),
+              child: CircleAvatar(
+                radius: 18,
+                backgroundImage:
+                    NetworkImage(userProvider.profileImageUrl),
+                backgroundColor:
+                    AppColors.neonCyan.withValues(alpha: 0.2),
+              ),
+            ),
+          ),
+        ],
+        elevation: 0,
+        backgroundColor:
+            Theme.of(context).scaffoldBackgroundColor,
+        surfaceTintColor: Colors.transparent,
       ),
       body: IndexedStack(
         index: _currentIndex,
@@ -46,36 +137,48 @@ class _HomeScreenState extends State<HomeScreen> {
         ),
         child: BottomNavigationBar(
           currentIndex: _currentIndex,
-          onTap: (index) => setState(() => _currentIndex = index),
+          onTap: (i) => setState(() => _currentIndex = i),
           type: BottomNavigationBarType.fixed,
           backgroundColor: Theme.of(context).colorScheme.surface,
-          selectedItemColor: Theme.of(context).primaryColor,
+          selectedItemColor: AppColors.neonCyan,
           unselectedItemColor: Colors.white38,
           showUnselectedLabels: true,
-          selectedLabelStyle: const TextStyle(fontWeight: FontWeight.bold, fontSize: 12),
+          selectedLabelStyle: const TextStyle(
+              fontWeight: FontWeight.bold, fontSize: 12),
           unselectedLabelStyle: const TextStyle(fontSize: 10),
-          items: const [
-            BottomNavigationBarItem(
+          items: [
+            const BottomNavigationBarItem(
               icon: Icon(Icons.psychology_outlined),
               activeIcon: Icon(Icons.psychology),
               label: 'Agente IA',
             ),
-            BottomNavigationBarItem(
+            const BottomNavigationBarItem(
               icon: Icon(Icons.bar_chart_outlined),
               activeIcon: Icon(Icons.bar_chart),
               label: 'Indicadores',
             ),
+            // Badge no item Operacional se houver alertas
             BottomNavigationBarItem(
-              icon: Icon(Icons.inventory_2_outlined),
-              activeIcon: Icon(Icons.inventory_2),
+              icon: alertCount > 0
+                  ? Badge(
+                      label: Text('$alertCount'),
+                      child: const Icon(Icons.inventory_2_outlined),
+                    )
+                  : const Icon(Icons.inventory_2_outlined),
+              activeIcon: alertCount > 0
+                  ? Badge(
+                      label: Text('$alertCount'),
+                      child: const Icon(Icons.inventory_2),
+                    )
+                  : const Icon(Icons.inventory_2),
               label: 'Operacional',
             ),
-            BottomNavigationBarItem(
+            const BottomNavigationBarItem(
               icon: Icon(Icons.account_balance_wallet_outlined),
               activeIcon: Icon(Icons.account_balance_wallet),
               label: 'Financeiro',
             ),
-            BottomNavigationBarItem(
+            const BottomNavigationBarItem(
               icon: Icon(Icons.admin_panel_settings_outlined),
               activeIcon: Icon(Icons.admin_panel_settings),
               label: 'Governança',

--- a/frontend/lib/presentation/screens/settings_screen.dart
+++ b/frontend/lib/presentation/screens/settings_screen.dart
@@ -1,145 +1,99 @@
+// PR-D — SettingsScreen: logout real, URL da API configurável, tenantId dinâmico, role do JWT
 import 'package:flutter/material.dart';
-import 'package:frontend/core/providers/user_provider.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
+import 'package:frontend/core/providers/user_provider.dart';
+import 'package:frontend/core/services/api_service.dart';
+import 'package:frontend/presentation/theme/app_theme.dart';
 
-class SettingsScreen extends StatelessWidget {
+class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final userProvider = Provider.of<UserProvider>(context);
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
 
-    return ListView(
-      padding: const EdgeInsets.all(16),
-      children: [
-        // Profile Header (Clickable)
-        GestureDetector(
-          onTap: () => _showEditProfile(context),
-          child: Container(
-            padding: const EdgeInsets.all(24),
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                colors: [
-                  Theme.of(context).colorScheme.surface,
-                  Theme.of(context).colorScheme.surface.withValues(alpha: 0.8),
-                ],
-              ),
-              borderRadius: BorderRadius.circular(20),
-              border: Border.all(color: Theme.of(context).primaryColor.withValues(alpha: 0.1)),
-            ),
-            child: Row(
-              children: [
-                Stack(
-                  children: [
-                    CircleAvatar(
-                      radius: 35,
-                      backgroundImage: NetworkImage(userProvider.profileImageUrl),
-                      backgroundColor: Theme.of(context).primaryColor.withValues(alpha: 0.1),
-                    ),
-                    Positioned(
-                      bottom: 0,
-                      right: 0,
-                      child: Container(
-                        padding: const EdgeInsets.all(4),
-                        decoration: BoxDecoration(
-                          color: Theme.of(context).colorScheme.secondary,
-                          shape: BoxShape.circle,
-                        ),
-                        child: const Icon(Icons.edit, size: 12, color: Colors.white),
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(width: 20),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        userProvider.adminName,
-                        style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
-                      ),
-                      Text(
-                        'Administrador Master',
-                        style: TextStyle(color: Theme.of(context).colorScheme.secondary, fontWeight: FontWeight.w500),
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        userProvider.companyName,
-                        style: const TextStyle(fontSize: 14, color: Colors.grey),
-                      ),
-                    ],
-                  ),
-                ),
-                const Icon(Icons.chevron_right, color: Colors.grey),
-              ],
-            ),
-          ),
-        ),
-        const SizedBox(height: 32),
-        const Text(
-          'Configurações da Conta',
-          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-        ),
-        const SizedBox(height: 16),
-        ListTile(
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-          tileColor: Theme.of(context).colorScheme.surface,
-          leading: const Icon(Icons.business),
-          title: const Text('Fábrica Sofa-Bed Alpha'),
-          subtitle: const Text('Tenant: 4d72a43d-ecf7-4190-b3cf-35603e1dcdb6'),
-          trailing: const Icon(Icons.copy, size: 16),
-        ),
-        const SizedBox(height: 32),
-        const Text(
-          'Governança de Dados (IA)',
-          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-        ),
-        const SizedBox(height: 16),
-        _buildGovernanceCard(
-          context,
-          'Transparência OCR',
-          'Nenhum documento financeiro (NF) processado via chat é gravado em disco (LGPD). A extração usa RAM.',
-          Icons.memory,
-        ),
-        const SizedBox(height: 12),
-        _buildGovernanceCard(
-          context,
-          'Agente de Compras',
-          'Decisões autônomas bloqueadas para movimentações > 1000 UN ou R\$ 5.000 (Human-in-the-Loop ativo).',
-          Icons.pan_tool,
-        ),
-        const SizedBox(height: 12),
-        _buildGovernanceCard(
-          context,
-          'Auditoria LLM',
-          'Intenções são validadas por LangChain parsers. Zero risco de alucinação JSON.',
-          Icons.gavel,
-        ),
-        const SizedBox(height: 32),
-        ElevatedButton.icon(
-          onPressed: () {},
-          style: ElevatedButton.styleFrom(
-            backgroundColor: Colors.redAccent.withValues(alpha: 0.2),
-            foregroundColor: Colors.redAccent,
-            padding: const EdgeInsets.all(16),
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-          ),
-          icon: const Icon(Icons.logout),
-          label: const Text('Desconectar (Limpar JWT)', style: TextStyle(fontWeight: FontWeight.bold)),
-        )
-      ],
-    );
+class _SettingsScreenState extends State<SettingsScreen> {
+  late TextEditingController _apiUrlCtrl;
+  bool _savingUrl = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _apiUrlCtrl =
+        TextEditingController(text: ApiService.instance.baseUrl);
   }
 
+  @override
+  void dispose() {
+    _apiUrlCtrl.dispose();
+    super.dispose();
+  }
+
+  // ─── Logout real ───────────────────────────────────────────────────────────
+
+  Future<void> _logout() async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Desconectar'),
+        content:
+            const Text('Deseja sair e limpar o JWT desta sessão?'),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancelar')),
+          ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.neonRed,
+                  foregroundColor: Colors.white),
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Sair')),
+        ],
+      ),
+    );
+    if (confirm == true && mounted) {
+      await Provider.of<UserProvider>(context, listen: false)
+          .logout();
+      // Volta para OnboardingScreen / LoginScreen
+      if (mounted) {
+        Navigator.of(context)
+            .pushNamedAndRemoveUntil('/home', (_) => false);
+      }
+    }
+  }
+
+  // ─── Salvar URL da API ───────────────────────────────────────────────────
+
+  Future<void> _saveApiUrl() async {
+    final url = _apiUrlCtrl.text.trim();
+    if (url.isEmpty) return;
+    setState(() => _savingUrl = true);
+    await ApiService.instance.setBaseUrl(url);
+    if (mounted) {
+      setState(() => _savingUrl = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('URL da API salva com sucesso ✔️'),
+          backgroundColor: AppColors.neonGreen,
+        ),
+      );
+    }
+  }
+
+  // ─── Edit Profile ──────────────────────────────────────────────────────────
+
   void _showEditProfile(BuildContext context) {
-    final userProvider = Provider.of<UserProvider>(context, listen: false);
-    final nameController = TextEditingController(text: userProvider.adminName);
-    final companyController = TextEditingController(text: userProvider.companyName);
-    String selectedAvatar = userProvider.profileImageUrl;
+    final up =
+        Provider.of<UserProvider>(context, listen: false);
+    final nameCtrl =
+        TextEditingController(text: up.adminName);
+    final companyCtrl =
+        TextEditingController(text: up.companyName);
+    String selectedAvatar = up.profileImageUrl;
 
     final avatarPresets = [
-      'https://ui-avatars.com/api/?name=Admin&background=00BCD4&color=fff',
+      'https://ui-avatars.com/api/?name=${Uri.encodeComponent(up.adminName)}&background=00BCD4&color=fff',
       'https://ui-avatars.com/api/?name=Boss&background=FF9800&color=fff',
       'https://ui-avatars.com/api/?name=Manager&background=4CAF50&color=fff',
       'https://ui-avatars.com/api/?name=Owner&background=E91E63&color=fff',
@@ -148,78 +102,107 @@ class SettingsScreen extends StatelessWidget {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
-      backgroundColor: Colors.transparent,
-      builder: (context) => StatefulBuilder(
-        builder: (context, setModalState) => Container(
-          decoration: BoxDecoration(
-            color: Theme.of(context).scaffoldBackgroundColor,
-            borderRadius: const BorderRadius.vertical(top: Radius.circular(25)),
-          ),
-          padding: EdgeInsets.fromLTRB(20, 20, 20, MediaQuery.of(context).viewInsets.bottom + 20),
+      backgroundColor: AppColors.bgCard,
+      shape: const RoundedRectangleBorder(
+          borderRadius:
+              BorderRadius.vertical(top: Radius.circular(24))),
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setSheet) => Padding(
+          padding: EdgeInsets.fromLTRB(
+              20,
+              20,
+              20,
+              MediaQuery.of(ctx).viewInsets.bottom + 24),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Text('Editar Perfil Profissional', style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+              const Text('Editar Perfil',
+                  style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      color: AppColors.textHigh)),
               const SizedBox(height: 20),
-              const Text('Escolha seu Avatar:', style: TextStyle(fontSize: 14, color: Colors.grey)),
-              const SizedBox(height: 12),
+              // Avatares preset
+              const Text('Avatar:',
+                  style: TextStyle(
+                      color: AppColors.textLow, fontSize: 13)),
+              const SizedBox(height: 10),
               SizedBox(
                 height: 60,
                 child: ListView.builder(
                   scrollDirection: Axis.horizontal,
                   itemCount: avatarPresets.length,
-                  itemBuilder: (context, index) {
-                    final avatar = avatarPresets[index];
-                    final isSelected = selectedAvatar == avatar;
+                  itemBuilder: (_, i) {
+                    final av = avatarPresets[i];
+                    final sel = selectedAvatar == av;
                     return GestureDetector(
-                      onTap: () => setModalState(() => selectedAvatar = avatar),
+                      onTap: () =>
+                          setSheet(() => selectedAvatar = av),
                       child: Container(
-                        margin: const EdgeInsets.symmetric(horizontal: 8),
+                        margin: const EdgeInsets.symmetric(
+                            horizontal: 8),
                         decoration: BoxDecoration(
                           shape: BoxShape.circle,
                           border: Border.all(
-                            color: isSelected ? Colors.cyanAccent : Colors.transparent,
+                            color: sel
+                                ? AppColors.neonCyan
+                                : Colors.transparent,
                             width: 3,
                           ),
                         ),
                         child: CircleAvatar(
                           radius: 25,
-                          backgroundImage: NetworkImage(avatar),
+                          backgroundImage: NetworkImage(av),
                         ),
                       ),
                     );
                   },
                 ),
               ),
-              const SizedBox(height: 20),
-              TextField(
-                controller: nameController, 
-                decoration: const InputDecoration(labelText: 'Seu Nome', prefixIcon: Icon(Icons.person))
-              ),
               const SizedBox(height: 16),
               TextField(
-                controller: companyController, 
-                decoration: const InputDecoration(labelText: 'Nome da Empresa', prefixIcon: Icon(Icons.business))
+                controller: nameCtrl,
+                decoration: const InputDecoration(
+                    labelText: 'Seu Nome',
+                    prefixIcon: Icon(Icons.person)),
               ),
-              const SizedBox(height: 24),
+              const SizedBox(height: 12),
+              TextField(
+                controller: companyCtrl,
+                decoration: const InputDecoration(
+                    labelText: 'Nome da Empresa',
+                    prefixIcon: Icon(Icons.business)),
+              ),
+              const SizedBox(height: 20),
               SizedBox(
                 width: double.infinity,
                 child: ElevatedButton(
                   style: ElevatedButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(vertical: 16),
-                    backgroundColor: Theme.of(context).primaryColor,
-                    foregroundColor: Colors.black,
+                    padding:
+                        const EdgeInsets.symmetric(vertical: 14),
+                    backgroundColor: AppColors.neonCyan,
+                    foregroundColor: AppColors.bgDeep,
                   ),
-                  onPressed: () {
-                    userProvider.updateProfile(
-                      nameController.text,
-                      companyController.text,
+                  onPressed: () async {
+                    await up.updateProfile(
+                      nameCtrl.text,
+                      companyCtrl.text,
                       imageUrl: selectedAvatar,
                     );
-                    Navigator.pop(context);
-                    ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Perfil Atualizado com Sucesso!')));
+                    if (ctx.mounted) Navigator.pop(ctx);
+                    if (mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text(
+                              'Perfil atualizado ✔️'),
+                          backgroundColor: AppColors.neonGreen,
+                        ),
+                      );
+                    }
                   },
-                  child: const Text('Salvar Alterações', style: TextStyle(fontWeight: FontWeight.bold)),
+                  child: const Text('Salvar',
+                      style: TextStyle(
+                          fontWeight: FontWeight.bold)),
                 ),
               ),
             ],
@@ -229,27 +212,311 @@ class SettingsScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildGovernanceCard(BuildContext context, String title, String description, IconData icon) {
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Icon(icon, color: Theme.of(context).colorScheme.secondary),
-            const SizedBox(width: 16),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(title, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
-                  const SizedBox(height: 4),
-                  Text(description, style: TextStyle(color: Colors.white.withValues(alpha: 0.6))),
+  // ─── Build ─────────────────────────────────────────────────────────────────
+
+  @override
+  Widget build(BuildContext context) {
+    final up = Provider.of<UserProvider>(context);
+
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 40),
+      children: [
+        // ─ Perfil
+        GestureDetector(
+          onTap: () => _showEditProfile(context),
+          child: Container(
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: [
+                  AppColors.neonCyan.withValues(alpha: 0.12),
+                  AppColors.neonPurple.withValues(alpha: 0.08),
                 ],
               ),
+              borderRadius: BorderRadius.circular(20),
+              border: Border.all(
+                  color: AppColors.neonCyan
+                      .withValues(alpha: 0.2)),
             ),
-          ],
+            child: Row(
+              children: [
+                Stack(
+                  children: [
+                    CircleAvatar(
+                      radius: 34,
+                      backgroundImage:
+                          NetworkImage(up.profileImageUrl),
+                      backgroundColor:
+                          AppColors.neonCyan.withValues(alpha: 0.1),
+                    ),
+                    Positioned(
+                      bottom: 0,
+                      right: 0,
+                      child: Container(
+                        padding: const EdgeInsets.all(4),
+                        decoration: const BoxDecoration(
+                          color: AppColors.neonCyan,
+                          shape: BoxShape.circle,
+                        ),
+                        child: const Icon(Icons.edit,
+                            size: 11,
+                            color: AppColors.bgDeep),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(up.adminName,
+                          style: const TextStyle(
+                              fontSize: 20,
+                              fontWeight: FontWeight.bold,
+                              color: AppColors.textHigh)),
+                      const SizedBox(height: 2),
+                      // Role dinâmica do JWT
+                      Text(
+                        up.role == 'admin' || up.role == 'owner'
+                            ? 'Administrador Master'
+                            : 'Operador',
+                        style: TextStyle(
+                            color: AppColors.neonCyan,
+                            fontWeight: FontWeight.w600,
+                            fontSize: 13),
+                      ),
+                      const SizedBox(height: 3),
+                      Text(up.companyName,
+                          style: const TextStyle(
+                              fontSize: 13,
+                              color: AppColors.textLow)),
+                    ],
+                  ),
+                ),
+                const Icon(Icons.chevron_right,
+                    color: AppColors.textLow),
+              ],
+            ),
+          ),
         ),
+
+        const SizedBox(height: 28),
+
+        // ─ Configurações da Conta
+        _sectionTitle('Configurações da Conta'),
+        const SizedBox(height: 12),
+
+        // Tenant ID — dinâmico do JWT
+        _infoTile(
+          Icons.business,
+          up.companyName,
+          'Tenant: ${up.tenantId.isEmpty ? 'não autenticado' : up.tenantId}',
+          trailingWidget: up.tenantId.isNotEmpty
+              ? IconButton(
+                  icon: const Icon(Icons.copy,
+                      size: 16, color: AppColors.textLow),
+                  onPressed: () {
+                    Clipboard.setData(
+                        ClipboardData(text: up.tenantId));
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                          content: Text('Tenant ID copiado')),
+                    );
+                  },
+                )
+              : null,
+        ),
+
+        const SizedBox(height: 10),
+
+        // URL da API configurável
+        Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: AppColors.bgCard,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: AppColors.border),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Row(
+                children: [
+                  Icon(Icons.api, color: AppColors.neonAmber, size: 18),
+                  SizedBox(width: 10),
+                  Text('URL do Servidor API',
+                      style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: AppColors.textHigh)),
+                ],
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _apiUrlCtrl,
+                keyboardType: TextInputType.url,
+                style: const TextStyle(
+                    fontSize: 13, color: AppColors.textHigh),
+                decoration: InputDecoration(
+                  hintText: 'http://seu-servidor:8000',
+                  contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 12, vertical: 10),
+                  filled: true,
+                  fillColor: AppColors.bgSurface,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(10),
+                    borderSide:
+                        const BorderSide(color: AppColors.border),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 10),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.neonAmber,
+                    foregroundColor: AppColors.bgDeep,
+                    padding: const EdgeInsets.symmetric(vertical: 10),
+                    shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(10)),
+                  ),
+                  onPressed: _savingUrl ? null : _saveApiUrl,
+                  child: _savingUrl
+                      ? const SizedBox(
+                          height: 18,
+                          width: 18,
+                          child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: AppColors.bgDeep))
+                      : const Text('Salvar URL',
+                          style: TextStyle(
+                              fontWeight: FontWeight.bold)),
+                ),
+              ),
+            ],
+          ),
+        ),
+
+        const SizedBox(height: 28),
+
+        // ─ Governança de Dados (IA)
+        _sectionTitle('Governança de Dados (IA)'),
+        const SizedBox(height: 12),
+        _govCard(
+          'Transparência OCR',
+          'Nenhum documento financeiro (NF) processado via chat é gravado em disco (LGPD). A extração usa RAM.',
+          Icons.memory,
+          AppColors.neonCyan,
+        ),
+        const SizedBox(height: 10),
+        _govCard(
+          'Agente de Compras',
+          'Decisões autônomas bloqueadas para movimentações > 1000 UN ou R\$ 5.000 (Human-in-the-Loop ativo).',
+          Icons.pan_tool,
+          AppColors.neonAmber,
+        ),
+        const SizedBox(height: 10),
+        _govCard(
+          'Auditoria LLM',
+          'Intenções validadas por parsers estruturados. Zero risco de alucinação JSON.',
+          Icons.gavel,
+          AppColors.neonPurple,
+        ),
+
+        const SizedBox(height: 32),
+
+        // ─ Botão Logout real
+        ElevatedButton.icon(
+          onPressed: _logout,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: AppColors.neonRed.withValues(alpha: 0.15),
+            foregroundColor: AppColors.neonRed,
+            padding: const EdgeInsets.all(16),
+            shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(14)),
+            side: BorderSide(
+                color: AppColors.neonRed.withValues(alpha: 0.4)),
+          ),
+          icon: const Icon(Icons.logout),
+          label: const Text('Desconectar (Limpar JWT)',
+              style: TextStyle(fontWeight: FontWeight.bold)),
+        ),
+      ],
+    );
+  }
+
+  // ─── Helpers ────────────────────────────────────────────────────────────
+
+  Widget _sectionTitle(String t) => Text(t,
+      style: const TextStyle(
+          fontSize: 17,
+          fontWeight: FontWeight.bold,
+          color: AppColors.textHigh));
+
+  Widget _infoTile(IconData icon, String title, String subtitle,
+      {Widget? trailingWidget}) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.bgCard,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: ListTile(
+        leading: Icon(icon, color: AppColors.textLow),
+        title: Text(title,
+            style: const TextStyle(color: AppColors.textHigh)),
+        subtitle: Text(subtitle,
+            style: const TextStyle(
+                fontSize: 11, color: AppColors.textLow)),
+        trailing: trailingWidget,
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      ),
+    );
+  }
+
+  Widget _govCard(
+      String title, String desc, IconData icon, Color color) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: AppColors.bgCard,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(
+            color: color.withValues(alpha: 0.2)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(icon, color: color, size: 18),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title,
+                    style: const TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 14,
+                        color: AppColors.textHigh)),
+                const SizedBox(height: 4),
+                Text(desc,
+                    style: const TextStyle(
+                        color: AppColors.textLow,
+                        fontSize: 12,
+                        height: 1.4)),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## PR #D — HomeScreen + SettingsScreen + DashboardScreen

> **Requer PR #A merged** (depende de `UserProvider.logout()`, `UserProvider.tenantId/role`, `ApiService.setBaseUrl()`, `OperationalProvider.totalStockValue/lowStockItems/totalItems`)

---

## Arquivos alterados (3)

---

### `presentation/screens/home_screen.dart` — REFATORADO

| Antes | Depois |
|---|---|
| `AppBar` com título fixo 'S.F.C.P.C - Logística Agêntica' | Título muda por aba (`_titles[_currentIndex]`) + subtítulo com `companyName` |
| Sem avatar na AppBar | `CircleAvatar` com `profileImageUrl` → tap vai para Governânça |
| Sem alertas visíveis | `Badge` no item **Operacional** com contagem de `lowStockItems` |
| Sem notificação | `IconButton` com badge vermelho na AppBar → navega direto para aba Operacional |
| `selectedItemColor` hardcoded | Usa `AppColors.neonCyan` do design system |

---

### `presentation/screens/settings_screen.dart` — REFATORADO COMPLETO

| Antes | Depois |
|---|---|
| `StatelessWidget` | `StatefulWidget` (necessário para `_apiUrlCtrl` e `_savingUrl`) |
| Botão logout sem ação (`onPressed: () {}`) | `_logout()` chama `UserProvider.logout()` real com dialog de confirmação |
| Sem campo de URL da API | Campo `TextField` com `ApiService.instance.setBaseUrl()` persistido |
| TenantID hardcoded `4d72a43d...` | `up.tenantId` dinâmico do JWT + botão copiar |
| Role sempre 'Administrador Master' | `up.role` do JWT: 'admin/owner' → 'Administrador Master', demais → 'Operador' |
| Cards de Governança sem cor | Ícones coloridos por `AppColors` (cyan, amber, purple) |
| `updateProfile` sem `await` | `await up.updateProfile()` correto |
| Avatar preset usa nome fixo 'Admin' | Primeiro avatar usa `up.adminName` dinâmico |

---

### `presentation/screens/dashboard_screen.dart` — REFATORADO

| Antes | Depois |
|---|---|
| `_capital` com `Random().nextDouble()` fake | `op.totalStockValue / 1000` real do `OperationalProvider` |
| `_rupturas` aleatório via `Timer` | `op.lowStockItems.length` real |
| Sem `totalItens` | 3º KPI card: `op.totalItems` |
| `Timer` gerando ruído a cada 10s | `Timer` a cada 30s apenas para `setState()` (re-render limpo) |
| Gráfico com `_capital % 5` nos spots | `_trendSpots` constantes — limpos, sem dependência de Random |
| Sem labels no eixo X do gráfico | `_trendLabels` (Out…Mar) com `getTitlesWidget` correto |
| Sem Forecast | Chama `ApiService.getForecast(critical.code)` e exibe se disponível |
| Sem `RefreshIndicator` | Pull-to-refresh chama `op.loadFromApi()` + `_loadForecast()` |
| Sem legenda no Pie | Row com 3 badges coloridos A/B/C |
| Cores hardcoded | Usa `AppColors` do design system |

---

## Resultado final após os 4 PRs mergeados

```
PR #A → Fundação (ApiService, models, providers)
PR #B → AgentScreen (HTTP real, scanner, OCR)
PR #C → OperationalScreen + FinancialScreen
PR #D → HomeScreen + Settings + Dashboard

App 100% conectado — zero dados fake críticos, zero ações nulas.
```