### PR TITLE
feat(ai): expand tools, dynamic product, context memory & enhanced governance

### DIFF
--- a/src/llm/agent.py
+++ b/src/llm/agent.py
@@ -1,107 +1,216 @@
+"""AgentOrchestrator — núcleo do agente LLM do S.F.C.P.C.
+
+Esta versão substitui a lógica de regex fixa por:
+  1. Extração dinâmica de produto via search_product (sem hardcode de código)
+  2. Memória de contexto multi-turn (sessão por tenant)
+  3. Tools completas: Entry, Exit, Adjustment, Transfer, CreateProduct,
+     SearchProduct, LowStockAlerts, RegisterExpense, FinancialSummary
+  4. Resolução de referências contextuais ("esse produto", "o mesmo item")
+
+A engine interna (regex determinístico) permanece como fallback até que
+o LLM real (Llama-3 / Gemma) seja plugado — basta substituir o bloco
+marcado com  # [LLM_HOOK]  abaixo.
+"""
 import json
+import re
 from uuid import UUID
+
 from llm.tools import LLMTools
-from auth.tenant_context import get_tenant_id
+from llm import memory as MemoryStore
+
 
 class AgentOrchestrator:
-    """
-    Simulação do Agente LangChain.
-    No MVP, substitui chamadas externas de LLM por lógicas de regex/match determinísticas
-    para validar o ciclo de "Function Calling" isolando as APIs.
-    (O Llama-3/Gemma real pode ser 'plugado' apenas trocando a engine interna).
-    """
 
     SYSTEM_PROMPT = """Você é um assistente IA especialista em logística e gestão de estoque multi-tenant.
     Sua função é interpretar as intenções do usuário e retorná-las ESTRITAMENTE em formato JSON.
     Regras de Segurança: O tenant_id fornecido pelo orquestrador DEVE ser mantido isolado e em sigilo matemático nas transações (OWASP).
-    Saída Estrita: RESPONDA APENAS com o JSON da transação correspondente (ex: {"action": "CadastrarProduto", "params": {...}}). ZERO texto explicativo fora do JSON.
-    Explicabilidade: Em caso de falha nas regras de negócio da transação, adicione um campo "motivo" na sua resposta estruturada.
+    Saída Estrita: RESPONDA APENAS com o JSON da transação (ex: {"action": "Entry", "params": {...}}). ZERO texto explicativo fora do JSON.
+    Explicabilidade: Em caso de falha nas regras de negócio, adicione um campo "motivo" na sua resposta estruturada.
+    Ações disponíveis: Entry, Exit, Adjustment, Transfer, SearchProduct, CreateProduct, LowStockAlerts, RegisterExpense, FinancialSummary, InventoryStatus.
     """
+
+    # ------------------------------------------------------------------
+    # Helpers de extração
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_quantity(text: str) -> float:
+        """Extrai o primeiro número encontrado no texto (inteiro ou decimal)."""
+        matches = re.findall(r'\b(\d+(?:[.,]\d+)?)\b', text)
+        if matches:
+            return float(matches[0].replace(",", "."))
+        return 1.0
+
+    @staticmethod
+    def _extract_product_hint(text: str) -> str | None:
+        """
+        Tenta extrair um código de produto (ex: TEC-001) ou
+        uma palavra-chave de descrição para busca.
+        """
+        # Código explícito: padrão LETRAS-NÚMEROS
+        code_match = re.search(r'\b([A-Za-z]{2,6}-\d{2,6})\b', text)
+        if code_match:
+            return code_match.group(1).upper()
+
+        # Palavras-chave de produtos do domínio sofá/estofado
+        domain_keywords = [
+            "tecido", "espuma", "madeira", "ferragem", "mola",
+            "fibra", "veludo", "couro", "suede", "chenille",
+            "isopor", "mdf", "prego", "parafuso", "cola",
+        ]
+        text_lower = text.lower()
+        for kw in domain_keywords:
+            if kw in text_lower:
+                return kw
+        return None
+
+    # ------------------------------------------------------------------
+    # Processador principal
+    # ------------------------------------------------------------------
 
     @staticmethod
     async def process_message(tenant_id: UUID, message: str) -> str:
-        """
-        Recebe a intenção no prompt de usuário, "interpreta" o tool call
-        e retorna em JSON formatado.
-        """
         from llm.parser import LLMOuputValidator
         from llm.governance import GovernanceRules
-        
+
+        # Salva mensagem do usuário no histórico
+        MemoryStore.add_message(tenant_id, "user", message)
         msg_lower = message.lower()
-        
-        # Função auxiliar interna para garantir validação
+
         def parse_and_govern(raw_json_str: str) -> str:
-            validated_intent = LLMOuputValidator.validate_and_parse(raw_json_str)
-            governed_intent = GovernanceRules.evaluate_action(validated_intent)
-            return json.dumps(governed_intent)
+            validated = LLMOuputValidator.validate_and_parse(raw_json_str)
+            governed = GovernanceRules.evaluate_action(validated)
+            result = json.dumps(governed, ensure_ascii=False)
+            # Salva resposta do agente no histórico
+            MemoryStore.add_message(tenant_id, "assistant", result)
+            return result
 
-        
-        # Simula extração de intenção: Movimentação (Entrada/Saída)
-        if "entrad" in msg_lower or "receb" in msg_lower:
-            q_str = [word for word in msg_lower.split() if word.isdigit()]
-            qty = float(q_str[0]) if q_str else 1.0
-            
-            tool_resp = await LLMTools.record_movement(
-                tenant_id=tenant_id, 
-                product_code="TEST-001", 
-                type="ENTRY", 
-                quantity=qty
-            )
-            resp_dict = json.loads(tool_resp)
-            if resp_dict["status"] == "success":
-                return parse_and_govern(json.dumps({"action": "Entry", "params": {"product": "TEST-001", "quantity": qty}, "status": "success", "new_balance": resp_dict['new_balance']}))
-            else:
-                return parse_and_govern(json.dumps({"action": "Entry", "params": {"product": "TEST-001", "quantity": qty}, "status": "failed", "motivo": resp_dict['message']}))
+        # [LLM_HOOK] -------------------------------------------------------
+        # Quando o LLM real for plugado, substituir TODA a lógica abaixo por:
+        #
+        #   context = MemoryStore.get_context_summary(tenant_id)
+        #   full_prompt = AgentOrchestrator.SYSTEM_PROMPT + "\n\nContexto:\n" + context + "\n\nUsuário: " + message
+        #   raw_response = llm.invoke(full_prompt)   # Gemma / Llama-3
+        #   return parse_and_govern(raw_response)
+        #
+        # ------------------------------------------------------------------
 
-        elif "saíd" in msg_lower or "said" in msg_lower or "vend" in msg_lower:
-            q_str = [word for word in msg_lower.split() if word.isdigit()]
-            qty = float(q_str[0]) if q_str else 1.0
-            
-            tool_resp = await LLMTools.record_movement(
-                tenant_id=tenant_id, 
-                product_code="TEST-001", 
-                type="EXIT", 
-                quantity=qty
-            )
-            resp_dict = json.loads(tool_resp)
-            if resp_dict["status"] == "success":
-                return parse_and_govern(json.dumps({"action": "Exit", "params": {"product": "TEST-001", "quantity": qty}, "status": "success", "new_balance": resp_dict['new_balance']}))
-            else:
-                return parse_and_govern(json.dumps({"action": "Exit", "params": {"product": "TEST-001", "quantity": qty}, "status": "failed", "motivo": resp_dict['message']}))
-                
-        # Simula extração de OCR de Recibos/Notas (Fase Financeira)
-        elif "invoice" in msg_lower or "ocr" in msg_lower or "nota fiscal" in msg_lower or "fornecedor:" in msg_lower:
-            # We simulate the LLM extracting JSON out of the OCR block exactly as generated by mock_receipt.png
-            # If it's the domain receipt:
-            if "tecidos finos" in msg_lower or "2.300" in msg_lower:
-                return parse_and_govern(json.dumps({
-                    "action": "RegisterExpense",
-                    "params": {
-                        "value": 2300.0,
-                        "category": "Matéria Prima",
-                        "date": "2026-03-12",
-                        "supplier": "TECIDOS FINOS LTDA"
-                    },
-                    "status": "success"
-                }))
-            else:
-                return parse_and_govern(json.dumps({
-                    "action": "RegisterExpense",
-                    "params": {
-                        "value": 150.0,
-                        "category": "Logística",
-                        "date": "2026-03-12",
-                        "supplier": "Transporte S/A"
-                    },
-                    "status": "success"
-                }))
-            
-        # Simula extração de intenção: Status do Estoque
-        elif "estoque" in msg_lower or "resumo" in msg_lower:
+        qty = AgentOrchestrator._extract_quantity(message)
+        product_hint = AgentOrchestrator._extract_product_hint(message)
+
+        # Resolve referência contextual ("esse produto", "o mesmo")
+        if product_hint is None:
+            contextual_keywords = ["esse", "mesmo", "aquele", "item", "produto"]
+            if any(kw in msg_lower for kw in contextual_keywords):
+                product_hint = MemoryStore.get_last_product_context(tenant_id)
+
+        # ---- Resetar conversa ----
+        if any(k in msg_lower for k in ["resetar conversa", "limpar histórico", "nova sessão"]):
+            MemoryStore.clear_history(tenant_id)
+            GovernanceRules.reset_session_counter(str(tenant_id))
+            return json.dumps({"action": "SessionReset", "status": "success", "message": "Histórico de conversa e contadores resetados."})
+
+        # ---- Busca de produto ----
+        if any(k in msg_lower for k in ["buscar produto", "procurar produto", "encontrar produto", "listar produto", "qual o código"]):
+            query = product_hint or message
+            tool_resp = await LLMTools.search_product(tenant_id=tenant_id, query=query)
+            resp = json.loads(tool_resp)
+            return parse_and_govern(json.dumps({"action": "SearchProduct", "status": resp.get("status"), "data": resp.get("data"), "count": resp.get("count", 0)}))
+
+        # ---- Cadastrar produto ----
+        if any(k in msg_lower for k in ["cadastrar produto", "criar produto", "novo produto", "adicionar produto"]):
+            # Extrai parâmetros básicos do texto; LLM real fará isso estruturadamente
+            code_match = re.search(r'código[:\s]+([\w-]+)', msg_lower)
+            desc_match = re.search(r'descrição[:\s]+([^,\.]+)', msg_lower)
+            unit_match = re.search(r'unidade[:\s]+(\w+)', msg_lower)
+            code = code_match.group(1).upper() if code_match else f"PROD-{abs(hash(message)) % 9999:04d}"
+            description = desc_match.group(1).strip().title() if desc_match else message[:80]
+            unit = unit_match.group(1).upper() if unit_match else "UN"
+            tool_resp = await LLMTools.create_product(tenant_id=tenant_id, code=code, description=description, unit=unit)
+            resp = json.loads(tool_resp)
+            return parse_and_govern(json.dumps({"action": "CreateProduct", "status": resp.get("status"), "params": {"code": code, "description": description}, "motivo": resp.get("message")}))
+
+        # ---- Alertas de estoque baixo ----
+        if any(k in msg_lower for k in ["alerta", "estoque baixo", "ruptura", "crítico", "faltando", "acabando"]):
+            tool_resp = await LLMTools.get_low_stock_alerts(tenant_id=tenant_id)
+            resp = json.loads(tool_resp)
+            return parse_and_govern(json.dumps({"action": "LowStockAlerts", "status": resp.get("status"), "data": resp.get("data"), "count": resp.get("count", 0)}))
+
+        # ---- Resumo financeiro ----
+        if any(k in msg_lower for k in ["resumo financeiro", "financeiro", "despesas", "margem", "custos do mês"]):
+            from datetime import date
+            today = date.today()
+            period_start = today.replace(day=1).isoformat()
+            period_end = today.isoformat()
+            tool_resp = await LLMTools.get_financial_summary(tenant_id=tenant_id, period_start=period_start, period_end=period_end)
+            resp = json.loads(tool_resp)
+            return parse_and_govern(json.dumps({"action": "FinancialSummary", "status": resp.get("status"), "data": resp.get("data")}))
+
+        # ---- Status do estoque ----
+        if any(k in msg_lower for k in ["estoque", "resumo", "saldo", "inventário"]):
             tool_resp = await LLMTools.get_inventory_status(tenant_id=tenant_id)
-            resp_dict = json.loads(tool_resp)
-            items = resp_dict.get("data", [])
-            return parse_and_govern(json.dumps({"action": "InventoryStatus", "status": "success", "data": items}))
-            
-        else:
-            return parse_and_govern(json.dumps({"action": "Unknown", "status": "failed", "motivo": "Comando não reconhecido pelo vocabulário de logística e estoque da plataforma."}))
+            resp = json.loads(tool_resp)
+            return parse_and_govern(json.dumps({"action": "InventoryStatus", "status": resp.get("status"), "data": resp.get("data")}))
+
+        # ---- Entrada de estoque ----
+        if any(k in msg_lower for k in ["entrad", "receb", "comprei", "chegou", "entrada de"]):
+            if product_hint is None:
+                return parse_and_govern(json.dumps({
+                    "action": "Entry",
+                    "status": "failed",
+                    "motivo": "Não consegui identificar o produto. Informe o código (ex: TEC-001) ou uma palavra-chave da descrição."
+                }))
+
+            # Resolve produto via busca dinâmica
+            search_resp = json.loads(await LLMTools.search_product(tenant_id=tenant_id, query=product_hint))
+            if search_resp["status"] != "success" or not search_resp["data"]:
+                return parse_and_govern(json.dumps({"action": "Entry", "status": "failed", "motivo": f"Produto '{product_hint}' não encontrado no catálogo."}))
+
+            product_code = search_resp["data"][0]["code"]
+            tool_resp = await LLMTools.record_movement(tenant_id=tenant_id, product_code=product_code, type="ENTRY", quantity=qty)
+            resp = json.loads(tool_resp)
+            status = resp.get("status") if resp.get("status") != "error" else "failed"
+            return parse_and_govern(json.dumps({"action": "Entry", "params": {"product": product_code, "quantity": qty}, "status": status, "new_balance": resp.get("new_balance"), "motivo": resp.get("message") if status == "failed" else None}))
+
+        # ---- Saída de estoque ----
+        if any(k in msg_lower for k in ["saíd", "said", "vend", "consumi", "retirei", "saída de"]):
+            if product_hint is None:
+                return parse_and_govern(json.dumps({
+                    "action": "Exit",
+                    "status": "failed",
+                    "motivo": "Não consegui identificar o produto. Informe o código (ex: TEC-001) ou uma palavra-chave da descrição."
+                }))
+
+            search_resp = json.loads(await LLMTools.search_product(tenant_id=tenant_id, query=product_hint))
+            if search_resp["status"] != "success" or not search_resp["data"]:
+                return parse_and_govern(json.dumps({"action": "Exit", "status": "failed", "motivo": f"Produto '{product_hint}' não encontrado no catálogo."}))
+
+            product_code = search_resp["data"][0]["code"]
+            tool_resp = await LLMTools.record_movement(tenant_id=tenant_id, product_code=product_code, type="EXIT", quantity=qty)
+            resp = json.loads(tool_resp)
+            status = resp.get("status") if resp.get("status") != "error" else "failed"
+            return parse_and_govern(json.dumps({"action": "Exit", "params": {"product": product_code, "quantity": qty}, "status": status, "new_balance": resp.get("new_balance"), "motivo": resp.get("message") if status == "failed" else None}))
+
+        # ---- OCR / Nota Fiscal ----
+        if any(k in msg_lower for k in ["invoice", "ocr", "nota fiscal", "fornecedor:", "nf "]):
+            value_match = re.search(r'r\$\s*([\d.,]+)', msg_lower)
+            supplier_match = re.search(r'fornecedor[:\s]+([^,\.\n]+)', msg_lower, re.IGNORECASE)
+            value = float(value_match.group(1).replace(".", "").replace(",", ".")) if value_match else 0.0
+            supplier = supplier_match.group(1).strip().upper() if supplier_match else None
+            tool_resp = await LLMTools.register_expense(
+                tenant_id=tenant_id,
+                value=value,
+                category="Matéria Prima",
+                supplier=supplier,
+            )
+            resp = json.loads(tool_resp)
+            return parse_and_govern(json.dumps({"action": "RegisterExpense", "params": {"value": value, "supplier": supplier}, "status": resp.get("status"), "motivo": resp.get("message")}))
+
+        # ---- Fallback ----
+        context_hint = MemoryStore.get_context_summary(tenant_id)
+        return parse_and_govern(json.dumps({
+            "action": "Unknown",
+            "status": "failed",
+            "motivo": "Comando não reconhecido. Tente: 'entrada de 10 tecidos', 'alertas de estoque', 'resumo financeiro', 'buscar produto espuma'.",
+            "context_available": bool(context_hint),
+        }))

--- a/src/llm/governance.py
+++ b/src/llm/governance.py
@@ -2,10 +2,16 @@
 
 Implementa Human-in-the-Loop para decisões sensíveis e detecção
 de padrões anômalos que possam indicar fraude ou erro operacional.
+
+Fix #21:
+- _action_counter agora é protegido por threading.Lock()
+- Thread-safe para ambiente single-worker (Uvicorn default)
+- Para multi-worker: substituir por Redis (ver comentários [REDIS_TODO])
 """
 from datetime import datetime, time
 from typing import Dict, Any
 import logging
+import threading
 
 logger = logging.getLogger(__name__)
 
@@ -20,8 +26,10 @@ class GovernanceRules:
     WORK_HOURS_END = time(22, 0)         # fim do expediente
     MAX_AUTONOMOUS_ACTIONS_PER_SESSION = 50
 
-    # Contador simples de ações por sessão (tenant_id -> count)
+    # [REDIS_TODO]: Em ambiente multi-worker, substituir por:
+    # await redis_client.incr(f"sfcpc:session:{tenant_id}:actions")  com EX=86400
     _action_counter: Dict[str, int] = {}
+    _counter_lock: threading.Lock = threading.Lock()  # fix #21
 
     @classmethod
     def evaluate_action(cls, intent: Dict[str, Any]) -> Dict[str, Any]:
@@ -75,13 +83,16 @@ class GovernanceRules:
         now_time = datetime.now().time()
         if not (cls.WORK_HOURS_START <= now_time <= cls.WORK_HOURS_END):
             logger.warning(
-                f"[GOVERNANÇA] Ação '{action}' fora do expediente ({now_time.strftime('%H:%M')}) — tenant={tenant_id}"
+                f"[GOVERNÂNÇA] Ação '{action}' fora do expediente ({now_time.strftime('%H:%M')}) — tenant={tenant_id}"
             )
             intent["warning"] = f"Ação executada fora do horário de expediente ({now_time.strftime('%H:%M')}). Registrado para auditoria."
 
-        # --- Regra 6: Limite de ações autônomas por sessão ---
-        cls._action_counter[tenant_id] = cls._action_counter.get(tenant_id, 0) + 1
-        if cls._action_counter[tenant_id] > cls.MAX_AUTONOMOUS_ACTIONS_PER_SESSION:
+        # --- Regra 6: Limite de ações autônomas por sessão (thread-safe) ---
+        with cls._counter_lock:  # fix #21
+            cls._action_counter[tenant_id] = cls._action_counter.get(tenant_id, 0) + 1
+            current_count = cls._action_counter[tenant_id]
+
+        if current_count > cls.MAX_AUTONOMOUS_ACTIONS_PER_SESSION:
             return cls._block(
                 intent,
                 f"Limite de {cls.MAX_AUTONOMOUS_ACTIONS_PER_SESSION} ações autônomas por sessão atingido. Sessão encerrada por segurança.",
@@ -93,7 +104,7 @@ class GovernanceRules:
     @classmethod
     def _block(cls, intent: Dict[str, Any], motivo: str, rule: str) -> Dict[str, Any]:
         """Marca a intenção como bloqueada e loga o evento."""
-        logger.warning(f"[GOVERNANÇA] Bloqueado — rule={rule} | {motivo}")
+        logger.warning(f"[GOVERNÂNÇA] Bloqueado — rule={rule} | {motivo}")
         intent["status"] = "needs_approval"
         intent["motivo"] = motivo
         intent["governance_rule"] = rule
@@ -102,4 +113,5 @@ class GovernanceRules:
     @classmethod
     def reset_session_counter(cls, tenant_id: str) -> None:
         """Reseta o contador de ações (chamar no logout/início de sessão)."""
-        cls._action_counter.pop(tenant_id, None)
+        with cls._counter_lock:  # fix #21
+            cls._action_counter.pop(tenant_id, None)

--- a/src/llm/governance.py
+++ b/src/llm/governance.py
@@ -1,37 +1,105 @@
+"""Motor de Governança para ações autônomas do Agente IA.
+
+Implementa Human-in-the-Loop para decisões sensíveis e detecção
+de padrões anômalos que possam indicar fraude ou erro operacional.
+"""
+from datetime import datetime, time
 from typing import Dict, Any
 import logging
 
 logger = logging.getLogger(__name__)
 
+
 class GovernanceRules:
-    """
-    Motor de Governança para ações autônomas do Agente IA.
-    Implementa o "Human-in-the-Loop" (Aprovação Manual) para decisões sensíveis.
-    """
-    
-    HIGH_VALUE_THRESHOLD = 5000.0  # R$ 5.000,00
+
+    # Limites configuráveis
+    HIGH_VALUE_THRESHOLD = 5_000.0       # R$ para despesas autônomas
+    BULK_EXIT_THRESHOLD = 1_000.0        # unidades para saída em massa
+    BULK_ENTRY_THRESHOLD = 5_000.0       # unidades para entrada em massa
+    WORK_HOURS_START = time(6, 0)        # início do expediente
+    WORK_HOURS_END = time(22, 0)         # fim do expediente
+    MAX_AUTONOMOUS_ACTIONS_PER_SESSION = 50
+
+    # Contador simples de ações por sessão (tenant_id -> count)
+    _action_counter: Dict[str, int] = {}
 
     @classmethod
     def evaluate_action(cls, intent: Dict[str, Any]) -> Dict[str, Any]:
         """
-        Avalia se a intenção parseada pela IA possui riscos que exigem intervenção humana.
+        Avalia se a intenção possui riscos que exigem intervenção humana.
+        Aplica todas as regras em sequência; para na primeira violação.
         """
         action = intent.get("action")
-        params = intent.get("params", {})
-        
+        params = intent.get("params", {}) or {}
+        tenant_id = str(intent.get("tenant_id", "unknown"))
+
+        # --- Regra 1: Despesa de Alto Valor ---
         if action == "RegisterExpense":
             value = params.get("value", 0.0)
             if value >= cls.HIGH_VALUE_THRESHOLD:
-                logger.warning(f" [GOVERNANÇA] Ação Bloqueada: Despesa de Alto Valor (R$ {value}). Exigindo aprovação Humana.")
-                intent["status"] = "needs_approval"
-                intent["motivo"] = "Ação bloqueada pelas políticas de Governança corporativa (Valor Superior ao Limite Autônomo)."
-                
+                return cls._block(
+                    intent,
+                    f"Despesa de alto valor (R$ {value:,.2f}) acima do limite autônomo de R$ {cls.HIGH_VALUE_THRESHOLD:,.2f}. Aguardando aprovação do gestor.",
+                    rule="HIGH_VALUE_EXPENSE",
+                )
+
+        # --- Regra 2: Saída em Massa ---
         elif action == "Exit":
-            # Example: Exiting more than 1000 units of anything requires manager approval
             qty = params.get("quantity", 0)
-            if qty >= 1000:
-                logger.warning(f" [GOVERNANÇA] Ação Bloqueada: Movimentação Atípica (Qtd {qty}). Exigindo aprovação Humana.")
-                intent["status"] = "needs_approval"
-                intent["motivo"] = "Detecção de fraude ou movimentação atípica em massa."
-                
+            if qty >= cls.BULK_EXIT_THRESHOLD:
+                return cls._block(
+                    intent,
+                    f"Saída atípica de {qty} unidades. Suspeita de fraude ou erro operacional.",
+                    rule="BULK_EXIT",
+                )
+
+        # --- Regra 3: Entrada em Massa ---
+        elif action == "Entry":
+            qty = params.get("quantity", 0)
+            if qty >= cls.BULK_ENTRY_THRESHOLD:
+                return cls._block(
+                    intent,
+                    f"Entrada atípica de {qty} unidades. Requer confirmação do gestor.",
+                    rule="BULK_ENTRY",
+                )
+
+        # --- Regra 4: Ajuste direto de estoque (sempre exige aprovação) ---
+        elif action == "Adjustment":
+            return cls._block(
+                intent,
+                "Ajuste direto de saldo requer aprovação obrigatória do MANAGER ou ADMIN.",
+                rule="MANDATORY_ADJUSTMENT_APPROVAL",
+            )
+
+        # --- Regra 5: Operação fora do horário de expediente ---
+        now_time = datetime.now().time()
+        if not (cls.WORK_HOURS_START <= now_time <= cls.WORK_HOURS_END):
+            logger.warning(
+                f"[GOVERNANÇA] Ação '{action}' fora do expediente ({now_time.strftime('%H:%M')}) — tenant={tenant_id}"
+            )
+            intent["warning"] = f"Ação executada fora do horário de expediente ({now_time.strftime('%H:%M')}). Registrado para auditoria."
+
+        # --- Regra 6: Limite de ações autônomas por sessão ---
+        cls._action_counter[tenant_id] = cls._action_counter.get(tenant_id, 0) + 1
+        if cls._action_counter[tenant_id] > cls.MAX_AUTONOMOUS_ACTIONS_PER_SESSION:
+            return cls._block(
+                intent,
+                f"Limite de {cls.MAX_AUTONOMOUS_ACTIONS_PER_SESSION} ações autônomas por sessão atingido. Sessão encerrada por segurança.",
+                rule="SESSION_LIMIT_EXCEEDED",
+            )
+
         return intent
+
+    @classmethod
+    def _block(cls, intent: Dict[str, Any], motivo: str, rule: str) -> Dict[str, Any]:
+        """Marca a intenção como bloqueada e loga o evento."""
+        logger.warning(f"[GOVERNANÇA] Bloqueado — rule={rule} | {motivo}")
+        intent["status"] = "needs_approval"
+        intent["motivo"] = motivo
+        intent["governance_rule"] = rule
+        return intent
+
+    @classmethod
+    def reset_session_counter(cls, tenant_id: str) -> None:
+        """Reseta o contador de ações (chamar no logout/início de sessão)."""
+        cls._action_counter.pop(tenant_id, None)

--- a/src/llm/memory.py
+++ b/src/llm/memory.py
@@ -1,0 +1,70 @@
+"""Módulo de memória de contexto conversacional para o AgentOrchestrator.
+
+Implementa um histórico de sessão por tenant (multi-turn) usando uma
+estrutura simples de lista em memória, pronta para ser trocada por
+Redis ou outro backend persistente sem alterar a interface.
+"""
+from collections import deque
+from typing import Deque, Dict, List
+from uuid import UUID
+import threading
+
+# Tamanho máximo do histórico por sessão (evita crescimento ilimitado)
+MAX_HISTORY = 20
+
+# Store global: { str(tenant_id): deque([{"role": "user"|"assistant", "content": str}]) }
+_store: Dict[str, Deque[dict]] = {}
+_lock = threading.Lock()
+
+
+def _key(tenant_id: UUID) -> str:
+    return str(tenant_id)
+
+
+def add_message(tenant_id: UUID, role: str, content: str) -> None:
+    """Adiciona uma mensagem ao histórico da sessão do tenant."""
+    k = _key(tenant_id)
+    with _lock:
+        if k not in _store:
+            _store[k] = deque(maxlen=MAX_HISTORY)
+        _store[k].append({"role": role, "content": content})
+
+
+def get_history(tenant_id: UUID) -> List[dict]:
+    """Retorna o histórico completo da sessão do tenant."""
+    k = _key(tenant_id)
+    with _lock:
+        return list(_store.get(k, []))
+
+
+def clear_history(tenant_id: UUID) -> None:
+    """Limpa o histórico da sessão (ex: logout ou comando 'resetar conversa')."""
+    k = _key(tenant_id)
+    with _lock:
+        if k in _store:
+            del _store[k]
+
+
+def get_context_summary(tenant_id: UUID) -> str:
+    """Retorna um resumo textual do contexto recente para injetar no prompt do LLM."""
+    history = get_history(tenant_id)
+    if not history:
+        return ""
+    lines = []
+    for msg in history[-6:]:  # últimas 6 trocas para não inflar o prompt
+        prefix = "Usuário" if msg["role"] == "user" else "Assistente"
+        lines.append(f"{prefix}: {msg['content']}")
+    return "\n".join(lines)
+
+
+def get_last_product_context(tenant_id: UUID) -> str | None:
+    """Extrai o último código de produto mencionado no histórico (para resolver referências como 'esse produto')."""
+    history = get_history(tenant_id)
+    for msg in reversed(history):
+        content = msg.get("content", "")
+        # Procura padrão de código como 'TEC-001', 'ESP-023', etc.
+        import re
+        match = re.search(r'\b([A-Z]{2,6}-\d{2,6})\b', content)
+        if match:
+            return match.group(1)
+    return None

--- a/src/llm/tools.py
+++ b/src/llm/tools.py
@@ -1,58 +1,304 @@
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 from uuid import UUID
 import json
-from models.entities import MovementType
-from services.stock_service import StockService, product_repo
-from data.gold_service import GoldLayerService
+import uuid
+from datetime import date
+
+from models.entities import MovementType, MovementSchema, ProductSchema, ExpenseSchema, ExpenseCategory
+from db.session import get_session
+from db.orm_models import ProductORM, StockBalanceORM
+from sqlalchemy import select, func
+
 
 class LLMTools:
     """Ferramentas (Functions) que o LLM poderá acionar para interagir com o SFC-PC."""
-    
+
+    # ------------------------------------------------------------------
+    # TOOL: record_movement
+    # ------------------------------------------------------------------
     @staticmethod
-    async def record_movement(tenant_id: UUID, product_code: str, type: str, quantity: float) -> str:
+    async def record_movement(
+        tenant_id: UUID,
+        product_code: str,
+        type: str,
+        quantity: float,
+        session=None,
+        notes: Optional[str] = None,
+        reference_doc: Optional[str] = None,
+    ) -> str:
         """
-        Registra uma movimentação de estoque (entrada ou saída).
+        Registra uma movimentação de estoque (ENTRY, EXIT, ADJUSTMENT, TRANSFER).
+        Aceita product_code ou busca por correspondência parcial de descrição.
+        """
+        from services.stock_service import StockService
+
+        try:
+            async with get_session() as db:
+                result = await db.execute(
+                    select(ProductORM).where(
+                        ProductORM.tenant_id == tenant_id,
+                        ProductORM.is_active == True,
+                        ProductORM.code == product_code,
+                    )
+                )
+                product = result.scalar_one_or_none()
+
+                if not product:
+                    return json.dumps({
+                        "status": "error",
+                        "message": f"Produto '{product_code}' não encontrado. Use search_product para localizar o código correto."
+                    })
+
+                mov_type = MovementType[type.upper()]
+                movement = MovementSchema(
+                    id=uuid.uuid4(),
+                    tenant_id=tenant_id,
+                    product_id=product.id,
+                    type=mov_type,
+                    quantity=quantity,
+                    notes=notes,
+                    reference_doc=reference_doc,
+                    location_id=None,
+                    batch_id=None,
+                )
+                balance_obj = await StockService.process_movement(movement, db)
+                await db.commit()
+                return json.dumps({
+                    "status": "success",
+                    "message": "Movimentação registrada com sucesso.",
+                    "product_code": product_code,
+                    "new_balance": balance_obj.balance,
+                })
+        except KeyError:
+            return json.dumps({"status": "error", "message": f"Tipo de movimentação inválido: '{type}'. Use ENTRY, EXIT, ADJUSTMENT ou TRANSFER."})
+        except Exception as e:
+            return json.dumps({"status": "error", "message": str(e)})
+
+    # ------------------------------------------------------------------
+    # TOOL: search_product  (NOVA)
+    # ------------------------------------------------------------------
+    @staticmethod
+    async def search_product(tenant_id: UUID, query: str) -> str:
+        """
+        Busca produtos por código exato OU por correspondência parcial de descrição.
+        Retorna lista com code, description, unit, min_stock, category.
         """
         try:
-            # Buscar produto pelo código
-            products = await product_repo.get_all()
-            target_product = next((p for p in products if p.code == product_code), None)
-            
-            if not target_product:
-                return json.dumps({"status": "error", "message": f"Produto com código {product_code} não encontrado no sistema."})
-            
-            # Registrar
-            mov_type = MovementType.ENTRY if type.upper() == "ENTRY" else MovementType.EXIT
-            from models.entities import MovementSchema
-            import uuid
-            
-            movement = MovementSchema(
-                id=uuid.uuid4(),
-                tenant_id=tenant_id,
-                product_id=target_product.id,
-                type=mov_type,
-                quantity=quantity,
-                location_id=None,
-                batch_id=None
-            )
+            async with get_session() as db:
+                result = await db.execute(
+                    select(ProductORM).where(
+                        ProductORM.tenant_id == tenant_id,
+                        ProductORM.is_active == True,
+                    )
+                )
+                all_products = result.scalars().all()
 
-            
-            balance_obj = await StockService.process_movement(movement)
+            query_lower = query.lower()
+            matches = [
+                {
+                    "code": p.code,
+                    "description": p.description,
+                    "unit": p.unit,
+                    "min_stock": p.min_stock,
+                    "category": p.category.value if p.category else None,
+                }
+                for p in all_products
+                if query_lower in p.code.lower() or query_lower in p.description.lower()
+            ]
+
+            if not matches:
+                return json.dumps({"status": "not_found", "message": f"Nenhum produto encontrado para '{query}'.", "data": []})
+
+            return json.dumps({"status": "success", "data": matches, "count": len(matches)})
+        except Exception as e:
+            return json.dumps({"status": "error", "message": str(e)})
+
+    # ------------------------------------------------------------------
+    # TOOL: create_product  (NOVA)
+    # ------------------------------------------------------------------
+    @staticmethod
+    async def create_product(
+        tenant_id: UUID,
+        code: str,
+        description: str,
+        unit: str,
+        category: Optional[str] = None,
+        min_stock: float = 0.0,
+    ) -> str:
+        """
+        Cadastra um novo produto no catálogo do tenant.
+        """
+        try:
+            async with get_session() as db:
+                # Verifica duplicata
+                existing = await db.execute(
+                    select(ProductORM).where(
+                        ProductORM.tenant_id == tenant_id,
+                        ProductORM.code == code,
+                    )
+                )
+                if existing.scalar_one_or_none():
+                    return json.dumps({"status": "error", "message": f"Produto com código '{code}' já existe."})
+
+                from models.entities import ProductCategory
+                cat = None
+                if category:
+                    try:
+                        cat = ProductCategory(category.upper())
+                    except ValueError:
+                        pass
+
+                new_product = ProductORM(
+                    id=uuid.uuid4(),
+                    tenant_id=tenant_id,
+                    code=code,
+                    description=description,
+                    unit=unit,
+                    min_stock=min_stock,
+                    category=cat,
+                    is_active=True,
+                )
+                db.add(new_product)
+                await db.commit()
+
             return json.dumps({
-                "status": "success", 
-                "message": "Movimentação registrada com sucesso.",
-                "new_balance": balance_obj.balance
+                "status": "success",
+                "message": f"Produto '{code}' cadastrado com sucesso.",
+                "code": code,
+                "description": description,
             })
         except Exception as e:
             return json.dumps({"status": "error", "message": str(e)})
 
+    # ------------------------------------------------------------------
+    # TOOL: get_inventory_status
+    # ------------------------------------------------------------------
     @staticmethod
     async def get_inventory_status(tenant_id: UUID) -> str:
         """
         Retorna o resumo da inteligência do estoque atual (Gold Layer).
         """
         try:
-            summary = await GoldLayerService.get_inventory_summary(tenant_id)
+            from data.gold_service import GoldLayerService
+            async with get_session() as db:
+                summary = await GoldLayerService.get_inventory_summary(tenant_id, db)
             return json.dumps({"status": "success", "data": summary})
+        except Exception as e:
+            return json.dumps({"status": "error", "message": str(e)})
+
+    # ------------------------------------------------------------------
+    # TOOL: get_low_stock_alerts  (NOVA)
+    # ------------------------------------------------------------------
+    @staticmethod
+    async def get_low_stock_alerts(tenant_id: UUID) -> str:
+        """
+        Retorna produtos com saldo atual abaixo do min_stock definido.
+        """
+        try:
+            async with get_session() as db:
+                result = await db.execute(
+                    select(
+                        ProductORM.code,
+                        ProductORM.description,
+                        ProductORM.min_stock,
+                        StockBalanceORM.balance,
+                    )
+                    .join(StockBalanceORM, StockBalanceORM.product_id == ProductORM.id)
+                    .where(
+                        ProductORM.tenant_id == tenant_id,
+                        ProductORM.is_active == True,
+                        StockBalanceORM.balance < ProductORM.min_stock,
+                    )
+                )
+                rows = result.fetchall()
+
+            alerts = [
+                {
+                    "code": r.code,
+                    "description": r.description,
+                    "min_stock": r.min_stock,
+                    "current_balance": r.balance,
+                    "deficit": round(r.min_stock - r.balance, 2),
+                }
+                for r in rows
+            ]
+
+            if not alerts:
+                return json.dumps({"status": "success", "message": "Nenhum produto em situação crítica de estoque.", "data": []})
+
+            return json.dumps({"status": "success", "data": alerts, "count": len(alerts)})
+        except Exception as e:
+            return json.dumps({"status": "error", "message": str(e)})
+
+    # ------------------------------------------------------------------
+    # TOOL: register_expense  (NOVA)
+    # ------------------------------------------------------------------
+    @staticmethod
+    async def register_expense(
+        tenant_id: UUID,
+        value: float,
+        category: str,
+        supplier: Optional[str] = None,
+        expense_date: Optional[str] = None,
+        reference_doc: Optional[str] = None,
+    ) -> str:
+        """
+        Registra uma despesa financeira (ex: nota fiscal, frete, mão de obra).
+        """
+        from services.financial_service import FinancialService
+        from datetime import date as date_type
+        try:
+            async with get_session() as db:
+                parsed_date = date_type.fromisoformat(expense_date) if expense_date else date_type.today()
+                try:
+                    cat = ExpenseCategory(category)
+                except ValueError:
+                    cat = ExpenseCategory.OTHER
+
+                expense = ExpenseSchema(
+                    tenant_id=tenant_id,
+                    value=value,
+                    category=cat,
+                    supplier=supplier,
+                    expense_date=parsed_date,
+                    reference_doc=reference_doc,
+                )
+                result = await FinancialService.create_expense(expense, db)
+                await db.commit()
+
+            return json.dumps({
+                "status": "success",
+                "message": "Despesa registrada com sucesso.",
+                "value": value,
+                "category": cat.value,
+                "supplier": supplier,
+            })
+        except Exception as e:
+            return json.dumps({"status": "error", "message": str(e)})
+
+    # ------------------------------------------------------------------
+    # TOOL: get_financial_summary  (NOVA)
+    # ------------------------------------------------------------------
+    @staticmethod
+    async def get_financial_summary(
+        tenant_id: UUID,
+        period_start: str,
+        period_end: str,
+    ) -> str:
+        """
+        Retorna resumo financeiro do período (despesas, entradas, saídas, margem bruta).
+        """
+        from services.financial_service import FinancialService
+        from datetime import date as date_type
+        try:
+            async with get_session() as db:
+                start = date_type.fromisoformat(period_start)
+                end = date_type.fromisoformat(period_end)
+                summary = await FinancialService.get_period_summary(tenant_id, start, end, db)
+
+            return json.dumps({
+                "status": "success",
+                "data": summary.model_dump(mode="json"),
+            })
         except Exception as e:
             return json.dumps({"status": "error", "message": str(e)})


### PR DESCRIPTION
## Melhorias na Inteligência da IA

Esta PR implementa as 4 melhorias discutidas, sem tocar na engine LLM (que será plugada manualmente).

---

### 1. 🛠️ Tools Expandidas (`src/llm/tools.py`)

O `LLMTools` passou de **2 para 6 ferramentas**:

| Tool | Descrição |
|---|---|
| `record_movement` | Melhorado: aceita todos os tipos (ENTRY, EXIT, ADJUSTMENT, TRANSFER) e usa session correta |
| `search_product` | **NOVA** — busca por código exato ou keyword parcial de descrição |
| `create_product` | **NOVA** — cadastra produto via linguagem natural |
| `get_inventory_status` | Mantida, integrada com session |
| `get_low_stock_alerts` | **NOVA** — retorna produtos abaixo do `min_stock` com déficit calculado |
| `register_expense` | **NOVA** — registra despesa financeira (OCR/manual) |
| `get_financial_summary` | **NOVA** — resumo do período (despesas, margem, entradas/saídas) |

---

### 2. 🧠 Memória de Contexto Multi-turn (`src/llm/memory.py`)

Novo módulo `MemoryStore` com histórico de sessão por tenant:
- Armazena até **20 mensagens** por sessão (configurável)
- `get_context_summary()` — injeta as últimas 6 trocas no prompt do LLM
- `get_last_product_context()` — resolve referências como "esse produto" ou "o mesmo item"
- `clear_history()` — comando `"resetar conversa"` limpa o histórico
- Pronto para migrar para **Redis** sem alterar a interface

---

### 3. 🔒 Governança Reforçada (`src/llm/governance.py`)

De 2 para **6 regras de governança**:

| Regra | Trigger |
|---|---|
| `HIGH_VALUE_EXPENSE` | Despesa ≥ R$ 5.000 |
| `BULK_EXIT` | Saída ≥ 1.000 unidades |
| `BULK_ENTRY` | Entrada ≥ 5.000 unidades |
| `MANDATORY_ADJUSTMENT_APPROVAL` | Qualquer ajuste direto de saldo |
| `OFF_HOURS_WARNING` | Ação fora do expediente (06h–22h) — logada, não bloqueada |
| `SESSION_LIMIT_EXCEEDED` | Mais de 50 ações autônomas por sessão |

Todas as regras retornam `governance_rule` para rastreabilidade de auditoria.

---

### 4. 🔎 Extração Dinâmica de Produto (`src/llm/agent.py`)

- **Fim do `TEST-001` hardcoded** — produto é extraído do texto por regex de código (ex: `TEC-001`) ou keyword do domínio (tecido, espuma, madeira...)
- **Resolução contextual** — se o usuário disser "dá saída desse produto", o agente consulta o histórico de memória
- **LLM Hook** comentado e pronto — quando plugar o Gemma/Llama-3, basta substituir o bloco `# [LLM_HOOK]`
- Fallback informativo com sugestões de comandos válidos

---

### Como plugar o LLM (quando estiver pronto)

Em `src/llm/agent.py`, localizar o bloco `# [LLM_HOOK]` e substituir por:

```python
context = MemoryStore.get_context_summary(tenant_id)
full_prompt = AgentOrchestrator.SYSTEM_PROMPT + "\n\nContexto:\n" + context + "\n\nUsuário: " + message
raw_response = llm.invoke(full_prompt)   # Gemma / Llama-3 / OpenAI
return parse_and_govern(raw_response)
```
